### PR TITLE
checking for workspaces based on which memberGroup they are in

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -160,10 +160,10 @@ func (w *WorkspaceDB) InitTables() error {
 	return nil
 }
 
-func (db *WorkspaceDB) GetUserWorkspaces(username string) ([]models.Workspace, error) {
+func (db *WorkspaceDB) GetUserWorkspaces(memberGroups []string) ([]models.Workspace, error) {
 
-	// Get the workspaces for the user
-	workspaces, err := db.getWorkspaces(username)
+	// Get the workspaces the user is a member of
+	workspaces, err := db.getWorkspaces(memberGroups)
 	if err != nil {
 		return nil, err
 	}
@@ -194,9 +194,9 @@ func (db *WorkspaceDB) GetUserWorkspaces(username string) ([]models.Workspace, e
 	return workspaces, nil
 }
 
-func (db *WorkspaceDB) getWorkspaces(username string) ([]models.Workspace, error) {
-	query := `SELECT id, name, account, accountowner, membergroup, status FROM workspaces WHERE accountowner = $1`
-	rows, err := db.DB.Query(query, username)
+func (db *WorkspaceDB) getWorkspaces(memberGroups []string) ([]models.Workspace, error) {
+	query := `SELECT id, name, account, accountowner, membergroup, status FROM workspaces WHERE memberGroup = ANY($1)`
+	rows, err := db.DB.Query(query, pq.Array(memberGroups))
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving workspaces: %v", err)
 	}
@@ -213,7 +213,7 @@ func (db *WorkspaceDB) getWorkspaces(username string) ([]models.Workspace, error
 	return workspaces, nil
 }
 
-// getBlockStores retrieves the block stores for each workspace in the provided list.
+// Retrieves the block stores for each workspace in the provided list.
 func (db *WorkspaceDB) getBlockStores(workspaces []models.Workspace) (map[uuid.UUID][]models.BlockStore, error) {
 	workspaceIDs := extractWorkspaceIDs(workspaces)
 	query := `
@@ -239,7 +239,7 @@ func (db *WorkspaceDB) getBlockStores(workspaces []models.Workspace) (map[uuid.U
 	return blockStores, nil
 }
 
-// getObjectStores retrieves the object stores for each workspace in the provided list.
+// Retrieves the object stores for each workspace in the provided list.
 func (db *WorkspaceDB) getObjectStores(workspaces []models.Workspace) (map[uuid.UUID][]models.ObjectStore, error) {
 	workspaceIDs := extractWorkspaceIDs(workspaces)
 	query := `

--- a/internal/authn/utils.go
+++ b/internal/authn/utils.go
@@ -11,8 +11,9 @@ var ErrInvalidClaims = errors.New("invalid claims")
 
 type Claims struct {
 	jwt.StandardClaims
-	Username    string `json:"preferred_username"`
-	RealmAccess struct {
+	Username     string   `json:"preferred_username"`
+	MemberGroups []string `json:"member_groups"`
+	RealmAccess  struct {
 		Roles []string `json:"roles"`
 	} `json:"realm_access"`
 }

--- a/internal/services/workspaces.go
+++ b/internal/services/workspaces.go
@@ -21,9 +21,8 @@ func GetWorkspacesService(workspaceDB *db.WorkspaceDB, w http.ResponseWriter, r 
 		return
 	}
 
-	// Retrieve user workspaces based on the username
-	// TODO: retrieve workspaces based on the member group
-	workspaces, err := workspaceDB.GetUserWorkspaces(claims.Username)
+	// Retrieve user workspaces based on the member_groups embedded in the claims
+	workspaces, err := workspaceDB.GetUserWorkspaces(claims.MemberGroups)
 	if err != nil {
 		workspaceDB.Log.Error().Err(err).Msg("Failed to retrieve workspaces for user")
 		http.Error(w, "Failed to retrieve workspaces", http.StatusInternalServerError) // TODO: encode proper error response


### PR DESCRIPTION
- Architecture to get user workspaces already in place.
- Switched to now use `member_groups` from the claims to check against the database
- The claim will show which groups the member is part of. It will query against the database to return records of those member groups.
