### PR TITLE
added /api/workspaces/<workspace> GET to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # EO DataHub Workspace Services
-An API gateway to the EO DataHub to manage workspace related API requests
+An API gateway to the EO DataHub to manage workspace related API requests and process events for workspace management.
 
 ## Getting Started
 ### Requisites
 - Go 1.16 or higher
+- Access to a PostgresSQL database
+- Apache Pulsar installed locally or access to a Pulsar cluster
 
 ### Installation
 Clone the repository:
@@ -23,6 +25,9 @@ database:
   source: postgres://{{.SQL_USER}}:{{.SQL_PASSWORD}}@{{.SQL_HOST}}:{{.SQL_PORT}}/{{.SQL_DATABASE}}?search_path={{.SQL_SCHEMA}}
 pulsar:
   url: pulsar://<<REPLACE>>
+  topicProducer: persistent://public/default/workspace-settings
+  topicConsumer: persistent://public/default/workspace-status
+  subscription: workspace-status-sub
 ```
 The repository connects to the workspaces database. In the cluster it will get it's connection string from env vars already setup. This config file is defined in the `eodhp-argocd-deployment` `app/workspace-services/base/config.yaml`
 
@@ -39,11 +44,19 @@ These details can be given upon request.
 ## Run with Pulsar Locally
 Make sure pulsar is installed. If you run `./pulsar standalone` and amend the config file to your localhost, then the app will attach to it.
 
-## Run Server:
-```go run main.go runserver --config /path/to/config.yaml```
+## Run the API Server:
+To start the server:
+
+```go run main.go serve --config /path/to/config.yaml```
 
 
 
+### Consume Workspace Events
+The `consume` command runs a Pulsar consumer that listens to events on the `workspace-status` topic and processes workspace updates in the database.
+
+To start the server:
+
+```go run main.go consume --config /path/to/config.yaml```
 
 ## Deployment
 - Push to the ECR:

--- a/api/handlers/workspace.go
+++ b/api/handlers/workspace.go
@@ -27,6 +27,14 @@ func GetWorkspaces(workspaceDB *db.WorkspaceDB) http.HandlerFunc {
 	}
 }
 
+// GetWorkspace handles HTTP requests for retrieving an individual workspace.
+func GetWorkspace(workspaceDB *db.WorkspaceDB) http.HandlerFunc {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		services.GetWorkspaceService(workspaceDB, w, r)
+	}
+}
+
 // UpdateWorkspace handles HTTP requests for updating a specific workspace by ID.
 // This is a placeholder for the actual implementation.
 func UpdateWorkspace(workspaceDB *db.WorkspaceDB) http.HandlerFunc {

--- a/api/services/utils.go
+++ b/api/services/utils.go
@@ -109,6 +109,16 @@ func HasRole(roles []string, role string) bool {
 	return false
 }
 
+// Helper function to check if a member group is in the claims array
+func isMemberGroupAuthorized(workspaceGroup string, claimsGroups []string) bool {
+	for _, group := range claimsGroups {
+		if workspaceGroup == group {
+			return true
+		}
+	}
+	return false
+}
+
 // isDNSCompatible returns true if the provided name is DNS-compatible
 func IsDNSCompatible(name string) bool {
 	return dnsNameRegex.MatchString(name)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -45,6 +45,7 @@ var serveCmd = &cobra.Command{
 		// Workspace routes
 		r.HandleFunc("/api/workspaces", middleware(handlers.CreateWorkspace(workspaceDB, publisher))).Methods(http.MethodPost)
 		r.HandleFunc("/api/workspaces", middleware(handlers.GetWorkspaces(workspaceDB))).Methods(http.MethodGet)
+		r.HandleFunc("/api/workspaces/{workspace-id}", middleware(handlers.GetWorkspace(workspaceDB))).Methods(http.MethodGet)
 		r.HandleFunc("/api/workspaces/{workspace-id}", middleware(handlers.UpdateWorkspace(workspaceDB))).Methods(http.MethodPut)
 		r.HandleFunc("/api/workspaces/{workspace-id}", middleware(handlers.PatchWorkspace(workspaceDB))).Methods(http.MethodPatch)
 

--- a/db/workspaces.go
+++ b/db/workspaces.go
@@ -12,6 +12,7 @@ import (
 // getWorkspace retrieves a workspace by name.
 func (db *WorkspaceDB) GetWorkspace(workspace_name string) (*ws_manager.WorkspaceSettings, error) {
 
+	// Check that the workspace exists
 	query := `SELECT id, name, account, member_group, status, last_updated FROM workspaces WHERE name = $1`
 	rows, err := db.DB.Query(query, workspace_name)
 	if err != nil {
@@ -27,7 +28,15 @@ func (db *WorkspaceDB) GetWorkspace(workspace_name string) (*ws_manager.Workspac
 	} else {
 		return nil, fmt.Errorf("workspace not found")
 	}
-	return &ws, nil
+
+	// Attach the stores to this workspace
+	workspaces := []ws_manager.WorkspaceSettings{ws}
+	workspacesWithStores, err := db.getWorkspaceStores(workspaces)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving workspace stores: %w", err)
+	}
+
+	return &workspacesWithStores[0], nil
 }
 
 // GetUserWorkspaces retrieves workspaces accessible to the specified member groups.


### PR DESCRIPTION
- I somehow missed out the `GET` on `/api/workspaces/workspace-name`
- This is now implemented. Only users within the same `members_group` in their claims can retrieve this information.
- Isaac spotted that this was not available and was needed for one of his tickets.

This has been tested locally.


- Updated README to reflect some previous changes too.