### PR TITLE
bug fixed - workspace appears after creation without token refresh

### DIFF
--- a/api/handlers/workspace.go
+++ b/api/handlers/workspace.go
@@ -28,6 +28,14 @@ func CreateWorkspace(svc *services.Service) http.HandlerFunc {
 func GetWorkspaces(svc *services.Service) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
+
+		// Get a token from keycloak so we can interact with it's API
+		err := svc.KC.GetToken()
+		if err != nil {
+			http.Error(w, "Authentication failed.", http.StatusInternalServerError)
+			return
+		}
+
 		services.GetWorkspacesService(svc, w, r)
 	}
 }
@@ -36,6 +44,14 @@ func GetWorkspaces(svc *services.Service) http.HandlerFunc {
 func GetWorkspace(svc *services.Service) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
+
+		// Get a token from keycloak so we can interact with it's API
+		err := svc.KC.GetToken()
+		if err != nil {
+			http.Error(w, "Authentication failed.", http.StatusInternalServerError)
+			return
+		}
+
 		services.GetWorkspaceService(svc, w, r)
 	}
 }

--- a/api/services/workspaces.go
+++ b/api/services/workspaces.go
@@ -26,8 +26,14 @@ func GetWorkspacesService(svc *Service, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Retrieve groups the user is a member of
+	memberGroups, err := svc.KC.GetUserGroups(claims.Subject)
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", claims.Subject).Msg("Failed to retrieve user groups")
+	}
+
 	// Retrieve workspaces assigned to these groups
-	workspaces, err := svc.DB.GetUserWorkspaces(claims.MemberGroups)
+	workspaces, err := svc.DB.GetUserWorkspaces(memberGroups)
 	if err != nil {
 		logger.Error().Err(err).Msg("Database error retrieving workspaces")
 		WriteResponse(w, http.StatusInternalServerError, nil)
@@ -70,8 +76,14 @@ func GetWorkspaceService(svc *Service, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Retrieve groups the user is a member of
+	memberGroups, err := svc.KC.GetUserGroups(claims.Subject)
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", claims.Subject).Msg("Failed to retrieve user groups")
+	}
+
 	// Check if the account owner matches any of the claims member groups
-	if !isMemberGroupAuthorized(workspace.MemberGroup, claims.MemberGroups) {
+	if !isMemberGroupAuthorized(workspace.MemberGroup, memberGroups) {
 		logger.Warn().Str("workspace_id", workspaceID).Str("user", claims.Username).Msg("Access denied: user not in authorized groups")
 		WriteResponse(w, http.StatusForbidden, nil)
 		return
@@ -165,12 +177,12 @@ func CreateWorkspaceService(svc *Service, w http.ResponseWriter, r *http.Request
 	accountOwnerID := claims.Subject
 	err = svc.KC.AddMemberToGroup(accountOwnerID, group.ID)
 	if err != nil {
-		logger.Error().Err(err).Str("group_id", group.ID).Msg("Failed to add user to group")
+		logger.Error().Err(err).Str("user_id", claims.Subject).Str("group_id", group.ID).Msg("Failed to add user to group")
 		WriteResponse(w, http.StatusInternalServerError, nil)
 		return
 	}
 
-	logger.Info().Str("group_id", group.ID).Msg("User added to Keycloak group successfully")
+	logger.Info().Str("user_id", claims.Subject).Str("group_id", group.ID).Msg("User added to Keycloak group successfully")
 
 	// Begin the workspace creation transaction
 	wsSettings.Status = "creating"

--- a/internal/authn/utils.go
+++ b/internal/authn/utils.go
@@ -11,9 +11,8 @@ var ErrInvalidClaims = errors.New("invalid claims")
 
 type Claims struct {
 	jwt.StandardClaims
-	Username     string   `json:"preferred_username"`
-	MemberGroups []string `json:"member_groups"`
-	RealmAccess  struct {
+	Username    string `json:"preferred_username"`
+	RealmAccess struct {
 		Roles []string `json:"roles"`
 	} `json:"realm_access"`
 }


### PR DESCRIPTION
Previously, workspace membership validation relied on token claims to check `member_group` claims. However, when a user created a workspace, their claims were not immediately updated within the same session, causing inconsistencies when checking membership right after creation.

To resolve this, we now retrieve the list of workspaces the user is a member of by making a direct API call to Keycloak within the GET /workspaces endpoint. This ensures that membership data is always up-to-date, eliminating the need to rely on stale token claims. 

I did look at other solutions but this seems most sensible as we are already using the Keycloak API for member management endpoints anyway (adding/removing members).

I don't know if the `member_groups` mapper in keycloak is needed anymore... perhaps its used elsewhere? If not I can remove it from the KC `realms.yaml` init as it seems abit redundant now.