### PR TITLE
added workspace scoped session endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: dockerbuild dockerpush test lint format setup clean docs publish
 
 # Variables
-VERSION ?= 0.7.0
+VERSION ?= 0.7.2
 IMAGENAME = eodhp-workspace-services
 DOCKERREPO ?= public.ecr.aws/eodh
 

--- a/api/handlers/s3.go
+++ b/api/handlers/s3.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const TimeFormat string = "2006-01-02T15:04:05Z"
 
 type STSClient interface {
 	AssumeRoleWithWebIdentity(ctx context.Context,

--- a/api/handlers/sessions.go
+++ b/api/handlers/sessions.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/EO-DataHub/eodhp-workspace-services/api/middleware"
+	services "github.com/EO-DataHub/eodhp-workspace-services/api/services"
+	"github.com/EO-DataHub/eodhp-workspace-services/internal/authn"
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog"
+)
+
+// @Summary Request workspace scoped session credentials
+// @Description Request workspace scoped session credentials for user access to a single workspace. {user-id} can be set to "me" to use the token owner's user id.
+// @Tags workspace session credentials auth
+// @Accept json
+// @Produce json
+// @Param workspace-id path string true "Workspace ID" example(my-workspace)
+// @Param user-id path string true "User ID" example(me)
+// @Success 200 {object} AuthSessionResponse
+// @Failure 400 {object} string
+// @Failure 401 {object} string
+// @Failure 403 {object} string
+// @Failure 500 {object} string
+// @Router /workspaces/{workspace-id}/{user-id}/session [post]
+func CreateWorkspaceSession(kc KeycloakClient) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		workspaceID := vars["workspace-id"]
+		userID := vars["user-id"]
+
+		logger := zerolog.Ctx(r.Context()).With().Str("workspace", workspaceID).
+			Logger()
+
+		token, ok := r.Context().Value(middleware.TokenKey).(string)
+		if !ok {
+			err := "Invalid token"
+			http.Error(w, err, http.StatusUnauthorized)
+			logger.Error().Msg(err)
+			return
+		}
+
+		logger.Debug().Str("token", token).Msg("Token retrieved")
+
+		claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
+		if !ok {
+			err := "Invalid claims"
+			logger.Error().Msg(err)
+			http.Error(w, err, http.StatusUnauthorized)
+			return
+		}
+
+		logger = logger.With().Str("claims user", claims.Username).Logger()
+
+		// Endpoint only currently supports session credentials for the token owner
+		if userID != "me" && userID != claims.Username {
+			err := "Endpoint does not support session credentials for users other than the token owner"
+			logger.Error().Msg(err)
+			http.Error(w, err, http.StatusBadRequest)
+		}
+
+		resp, err := kc.ExchangeToken(token, fmt.Sprintf("workspace:%s", workspaceID))
+		if err != nil {
+			var errStatus int
+			if err, ok := err.(*services.HTTPError); ok {
+				errStatus = err.Status
+			} else {
+				errStatus = http.StatusInternalServerError
+			}
+			logger.Error().Err(err).Msg("Failed to get offline token")
+			http.Error(w, err.Error(), errStatus)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		response := AuthSessionResponse{
+			Access: resp.Access,
+			AccessExpiry: time.Now().Add(time.Duration(resp.ExpiresIn) *
+				time.Second).Format(TimeFormat),
+			Refresh: resp.Refresh,
+			RefreshExpiry: time.Now().Add(time.Duration(resp.RefreshExpiresIn) *
+				time.Second).Format(TimeFormat),
+			Scope: resp.Scope,
+		}
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			logger.Error().Err(err).Msg("Failed to encode response")
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+}
+
+type AuthSessionResponse struct {
+	Access        string `json:"access"`
+	AccessExpiry  string `json:"accessExpiry"`
+	Refresh       string `json:"refresh"`
+	RefreshExpiry string `json:"refreshExpiry"`
+	Scope         string `json:"scope"`
+}

--- a/api/handlers/sessions_test.go
+++ b/api/handlers/sessions_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/EO-DataHub/eodhp-workspace-services/api/middleware"
+	services "github.com/EO-DataHub/eodhp-workspace-services/api/services"
+	"github.com/EO-DataHub/eodhp-workspace-services/internal/authn"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+type keycloakMock struct {
+	response *services.TokenResponse
+	err      error
+}
+
+func (k keycloakMock) ExchangeToken(token, scope string) (
+	*services.TokenResponse, error) {
+
+	if k.err != nil {
+		return nil, k.err
+	}
+
+	return k.response, nil
+}
+
+func TestCreateWorkspaceSession_Success(t *testing.T) {
+	kc := &keycloakMock{
+		response: &services.TokenResponse{
+			Access:           "access-token",
+			ExpiresIn:        3600,
+			Refresh:          "refresh-token",
+			RefreshExpiresIn: 7200,
+			Scope:            "workspace:test",
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/workspaces/{workspace-id}/{user-id}/sessions", nil)
+	req = mux.SetURLVars(req, map[string]string{"workspace-id": "test", "user-id": "me"})
+	ctx := context.WithValue(req.Context(), middleware.TokenKey, "valid-token")
+	ctx = context.WithValue(ctx, middleware.ClaimsKey, authn.Claims{Username: "user"})
+
+	w := httptest.NewRecorder()
+
+	handler := CreateWorkspaceSession(kc)
+	handler.ServeHTTP(w, req.WithContext(ctx))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response AuthSessionResponse
+	err := json.NewDecoder(w.Body).Decode(&response)
+	assert.NoError(t, err)
+	assert.Equal(t, "access-token", response.Access)
+	assert.Equal(t, "refresh-token", response.Refresh)
+	assert.Equal(t, "workspace:test", response.Scope)
+}
+
+func TestCreateWorkspaceSession_InvalidToken(t *testing.T) {
+	kc := &keycloakMock{
+		err: &services.HTTPError{Status: http.StatusUnauthorized, Message: "Invalid token"},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/workspaces/{workspace-id}/{user-id}/sessions", nil)
+	req = mux.SetURLVars(req, map[string]string{"workspace-id": "test", "user-id": "me"})
+	ctx := context.WithValue(req.Context(), middleware.TokenKey, "invalid-token")
+	ctx = context.WithValue(ctx, middleware.ClaimsKey, authn.Claims{Username: "user"})
+
+	w := httptest.NewRecorder()
+
+	handler := CreateWorkspaceSession(kc)
+	handler.ServeHTTP(w, req.WithContext(ctx))
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid token")
+}
+
+func TestCreateWorkspaceSession_ExchangeTokenError(t *testing.T) {
+	kc := &keycloakMock{
+		err: &services.HTTPError{Status: http.StatusForbidden, Message: "Forbidden"},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/workspaces/{workspace-id}/{user-id}/sessions", nil)
+	req = mux.SetURLVars(req, map[string]string{"workspace-id": "test", "user-id": "me"})
+	ctx := context.WithValue(req.Context(), middleware.TokenKey, "unauthorized-token")
+	ctx = context.WithValue(ctx, middleware.ClaimsKey, authn.Claims{Username: "user"})
+
+	rec := httptest.NewRecorder()
+
+	handler := CreateWorkspaceSession(kc)
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Forbidden")
+}
+
+func TestCreateWorkspaceSession_WrongUserError(t *testing.T) {
+	kc := &keycloakMock{
+		err: &services.HTTPError{Status: http.StatusForbidden, Message: "Forbidden"},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/workspaces/{workspace-id}/{user-id}/sessions", nil)
+	req = mux.SetURLVars(req, map[string]string{"workspace-id": "test", "user-id": "another-user"})
+	ctx := context.WithValue(req.Context(), middleware.TokenKey, "valid-token")
+	ctx = context.WithValue(ctx, middleware.ClaimsKey, authn.Claims{Username: "user"})
+
+	rec := httptest.NewRecorder()
+
+	handler := CreateWorkspaceSession(kc)
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/api/handlers/utils.go
+++ b/api/handlers/utils.go
@@ -1,0 +1,9 @@
+package handlers
+
+import services "github.com/EO-DataHub/eodhp-workspace-services/api/services"
+
+const TimeFormat string = "2006-01-02T15:04:05Z"
+
+type KeycloakClient interface {
+	ExchangeToken(token, scope string) (*services.TokenResponse, error)
+}

--- a/api/services/keycloak.go
+++ b/api/services/keycloak.go
@@ -22,9 +22,11 @@ type KeycloakClient struct {
 }
 
 type TokenResponse struct {
-	Access    string `json:"access_token"`
-	Refresh   string `json:"refresh_token"`
-	ExpiresIn int    `json:"expires_in"`
+	Access           string `json:"access_token"`
+	Refresh          string `json:"refresh_token"`
+	ExpiresIn        int    `json:"expires_in"`
+	RefreshExpiresIn int    `json:"refresh_expires_in"`
+	Scope            string `json:"scope"`
 }
 
 type KeycloakError struct {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -101,6 +101,9 @@ var serveCmd = &cobra.Command{
 		api.HandleFunc("/accounts/{account-id}", handlers.DeleteAccount(service)).Methods(http.MethodDelete)
 		api.HandleFunc("/accounts/{account-id}", handlers.UpdateAccount(service)).Methods(http.MethodPut)
 
+		// Workspace scoped session routes
+		api.HandleFunc("/workspaces/{workspace-id}/{user-id}/sessions", handlers.CreateWorkspaceSession(keycloakClient)).Methods(http.MethodPost)
+
 		// S3 token routes
 		api.HandleFunc("/workspaces/{workspace-id}/{user-id}/s3-tokens", handlers.RequestS3CredentialsHandler(appCfg.AWS.S3.RoleArn, sts_client, *keycloakClient)).Methods(http.MethodPost)
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -73,9 +73,94 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/workspaces/{workspace-id}/{user-id}/session": {
+            "post": {
+                "description": "Request workspace scoped session credentials for user access to a single workspace. {user-id} can be set to \"me\" to use the token owner's user id.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspace session credentials auth"
+                ],
+                "summary": "Request workspace scoped session credentials",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "my-workspace",
+                        "description": "Workspace ID",
+                        "name": "workspace-id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "me",
+                        "description": "User ID",
+                        "name": "user-id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.AuthSessionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "handlers.AuthSessionResponse": {
+            "type": "object",
+            "properties": {
+                "access": {
+                    "type": "string"
+                },
+                "accessExpiry": {
+                    "type": "string"
+                },
+                "refresh": {
+                    "type": "string"
+                },
+                "refreshExpiry": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.S3Credentials": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -65,9 +65,94 @@
                     }
                 }
             }
+        },
+        "/workspaces/{workspace-id}/{user-id}/session": {
+            "post": {
+                "description": "Request workspace scoped session credentials for user access to a single workspace. {user-id} can be set to \"me\" to use the token owner's user id.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspace session credentials auth"
+                ],
+                "summary": "Request workspace scoped session credentials",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "my-workspace",
+                        "description": "Workspace ID",
+                        "name": "workspace-id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "me",
+                        "description": "User ID",
+                        "name": "user-id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.AuthSessionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "handlers.AuthSessionResponse": {
+            "type": "object",
+            "properties": {
+                "access": {
+                    "type": "string"
+                },
+                "accessExpiry": {
+                    "type": "string"
+                },
+                "refresh": {
+                    "type": "string"
+                },
+                "refreshExpiry": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.S3Credentials": {
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,17 @@
 definitions:
+  handlers.AuthSessionResponse:
+    properties:
+      access:
+        type: string
+      accessExpiry:
+        type: string
+      refresh:
+        type: string
+      refreshExpiry:
+        type: string
+      scope:
+        type: string
+    type: object
   handlers.S3Credentials:
     properties:
       accessKeyId:
@@ -57,4 +70,50 @@ paths:
       summary: Request S3 session credentials
       tags:
       - s3 credentials auth
+  /workspaces/{workspace-id}/{user-id}/session:
+    post:
+      consumes:
+      - application/json
+      description: Request workspace scoped session credentials for user access to
+        a single workspace. {user-id} can be set to "me" to use the token owner's
+        user id.
+      parameters:
+      - description: Workspace ID
+        example: my-workspace
+        in: path
+        name: workspace-id
+        required: true
+        type: string
+      - description: User ID
+        example: me
+        in: path
+        name: user-id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.AuthSessionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Request workspace scoped session credentials
+      tags:
+      - workspace session credentials auth
 swagger: "2.0"


### PR DESCRIPTION
Add a session endpoint to convert user scoped tokens into workspace scoped tokens.

Tested on dev3 using cookie and bearer token auth in Postman.

```
curl --location --request POST 'https://dev3.eodatahub.org.uk/api/workspaces/sgillies-tpzuk/me/sessions' \
--header 'Authorization: Bearer eyJhbGciOiJSUzI1...'
```

Docs at https://dev3.eodatahub.org.uk/api/docs/workspace-services/index.html.