### PR TITLE
Feature/eodhp 1059 access control

### DIFF
--- a/api/handlers/workspace.go
+++ b/api/handlers/workspace.go
@@ -56,6 +56,23 @@ func GetWorkspace(svc *services.Service) http.HandlerFunc {
 	}
 }
 
+// DeleteWorkspace handles HTTP requests for deleting a workspace
+func DeleteWorkspace(svc *services.Service) http.HandlerFunc {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		// Get a token from keycloak so we can interact with it's API
+		err := svc.KC.GetToken()
+		if err != nil {
+			http.Error(w, "Authentication failed.", http.StatusInternalServerError)
+			return
+		}
+
+		services.DeleteWorkspaceService(svc, w, r)
+	}
+}
+
+
 // UpdateWorkspace handles HTTP requests for updating a specific workspace by ID.
 // This is a placeholder for the actual implementation.
 func UpdateWorkspace(svc *services.Service) http.HandlerFunc {

--- a/api/middleware/mw_test.go
+++ b/api/middleware/mw_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,4 +34,40 @@ func TestProxyAuthRequest_InvalidBearerToken_ClaimsNotPopulated(t *testing.T) {
 	mw := JWTMiddleware(next)
 	w := httptest.NewRecorder()
 	mw.ServeHTTP(w, req)
+}
+
+func TestDenyWorkspaceScopedTokens_Middleware_WorkspaceScoped(t *testing.T) {
+	// Define the next handler that will check if the claims are properly populated
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This should not be reached if the token is workspace-scoped
+		t.Fatal("Expected request to be blocked by DenyWorkspaceScopedTokens middleware")
+	})
+
+	// Create a mock request with a workspace-scoped token
+	workspaceClaims := authn.Claims{
+		Workspace: "user-scoped", 
+	}
+
+	// Mock the context with the workspace-scoped claims
+	ctx := context.WithValue(context.Background(), ClaimsKey, workspaceClaims)
+
+	// Create a mock JWT token for the workspace-scoped claims
+	token := "Bearer workspace-scoped-token"
+
+	// Set up the request with the workspace-scoped token
+	req, err := http.NewRequest("GET", "/accounts", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Authorization", token)
+	req = req.WithContext(ctx) 
+
+	mw := DenyWorkspaceScopedTokens(next)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	// Assert that the response status code is 401 Unauthorized for workspace-scoped tokens
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status 401 Unauthorized but got %v", w.Code)
+	}
 }

--- a/api/services/accounts.go
+++ b/api/services/accounts.go
@@ -28,13 +28,6 @@ func CreateAccountService(svc *Service, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Workspace Scoped tokens not authorized to access account information
-	if claims.Workspace != "" {
-		logger.Warn().Msg("Unauthorized request: workspace scoped token")
-		WriteResponse(w, http.StatusUnauthorized, nil)
-		return
-	}
-
 	// Decode the request payload into an Account struct
 	var messagePayload ws_services.Account
 	if err := json.NewDecoder(r.Body).Decode(&messagePayload); err != nil {
@@ -77,13 +70,6 @@ func GetAccountsService(svc *Service, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Workspace Scoped tokens not authorized to access account information
-	if claims.Workspace != "" {
-		logger.Warn().Msg("Unauthorized request: workspace scoped token")
-		WriteResponse(w, http.StatusUnauthorized, nil)
-		return
-	}
-
 	// Retrieve accounts associated with the user's username
 	accounts, err := svc.DB.GetAccounts(claims.Username)
 
@@ -112,13 +98,6 @@ func GetAccountService(svc *Service, w http.ResponseWriter, r *http.Request) {
 	claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
 	if !ok {
 		logger.Warn().Msg("Unauthorized request: missing claims")
-		WriteResponse(w, http.StatusUnauthorized, nil)
-		return
-	}
-
-	// Workspace Scoped tokens not authorized to access account information
-	if claims.Workspace != "" {
-		logger.Warn().Msg("Unauthorized request: workspace scoped token")
 		WriteResponse(w, http.StatusUnauthorized, nil)
 		return
 	}
@@ -164,21 +143,6 @@ func UpdateAccountService(svc *Service, w http.ResponseWriter, r *http.Request) 
 
 	logger := zerolog.Ctx(r.Context())
 
-	// Extract claims from the request context to identify the user
-	claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
-	if !ok {
-		logger.Warn().Msg("Unauthorized request: missing claims")
-		WriteResponse(w, http.StatusUnauthorized, nil)
-		return
-	}
-
-	// Workspace Scoped tokens not authorized to access account information
-	if claims.Workspace != "" {
-		logger.Warn().Msg("Unauthorized request: workspace scoped token")
-		WriteResponse(w, http.StatusUnauthorized, nil)
-		return
-	}
-
 	// Parse the account ID from the URL path
 	accountID, err := uuid.Parse(mux.Vars(r)["account-id"])
 
@@ -213,21 +177,6 @@ func UpdateAccountService(svc *Service, w http.ResponseWriter, r *http.Request) 
 func DeleteAccountService(svc *Service, w http.ResponseWriter, r *http.Request) {
 
 	logger := zerolog.Ctx(r.Context())
-
-	// Extract claims from the request context to identify the user
-	claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
-	if !ok {
-		logger.Warn().Msg("Unauthorized request: missing claims")
-		WriteResponse(w, http.StatusUnauthorized, nil)
-		return
-	}
-
-	// Workspace Scoped tokens not authorized to access account information
-	if claims.Workspace != "" {
-		logger.Warn().Msg("Unauthorized request: workspace scoped token")
-		WriteResponse(w, http.StatusUnauthorized, nil)
-		return
-	}
 
 	accountID, err := uuid.Parse(mux.Vars(r)["account-id"])
 	if err != nil {

--- a/api/services/accounts.go
+++ b/api/services/accounts.go
@@ -28,6 +28,13 @@ func CreateAccountService(svc *Service, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Workspace Scoped tokens not authorized to access account information
+	if claims.Workspace != "" {
+		logger.Warn().Msg("Unauthorized request: workspace scoped token")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
+
 	// Decode the request payload into an Account struct
 	var messagePayload ws_services.Account
 	if err := json.NewDecoder(r.Body).Decode(&messagePayload); err != nil {
@@ -70,6 +77,13 @@ func GetAccountsService(svc *Service, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Workspace Scoped tokens not authorized to access account information
+	if claims.Workspace != "" {
+		logger.Warn().Msg("Unauthorized request: workspace scoped token")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
+
 	// Retrieve accounts associated with the user's username
 	accounts, err := svc.DB.GetAccounts(claims.Username)
 
@@ -98,6 +112,13 @@ func GetAccountService(svc *Service, w http.ResponseWriter, r *http.Request) {
 	claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
 	if !ok {
 		logger.Warn().Msg("Unauthorized request: missing claims")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
+
+	// Workspace Scoped tokens not authorized to access account information
+	if claims.Workspace != "" {
+		logger.Warn().Msg("Unauthorized request: workspace scoped token")
 		WriteResponse(w, http.StatusUnauthorized, nil)
 		return
 	}
@@ -143,6 +164,21 @@ func UpdateAccountService(svc *Service, w http.ResponseWriter, r *http.Request) 
 
 	logger := zerolog.Ctx(r.Context())
 
+	// Extract claims from the request context to identify the user
+	claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
+	if !ok {
+		logger.Warn().Msg("Unauthorized request: missing claims")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
+
+	// Workspace Scoped tokens not authorized to access account information
+	if claims.Workspace != "" {
+		logger.Warn().Msg("Unauthorized request: workspace scoped token")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
+
 	// Parse the account ID from the URL path
 	accountID, err := uuid.Parse(mux.Vars(r)["account-id"])
 
@@ -177,6 +213,21 @@ func UpdateAccountService(svc *Service, w http.ResponseWriter, r *http.Request) 
 func DeleteAccountService(svc *Service, w http.ResponseWriter, r *http.Request) {
 
 	logger := zerolog.Ctx(r.Context())
+
+	// Extract claims from the request context to identify the user
+	claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
+	if !ok {
+		logger.Warn().Msg("Unauthorized request: missing claims")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
+
+	// Workspace Scoped tokens not authorized to access account information
+	if claims.Workspace != "" {
+		logger.Warn().Msg("Unauthorized request: workspace scoped token")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
 
 	accountID, err := uuid.Parse(mux.Vars(r)["account-id"])
 	if err != nil {

--- a/api/services/workspaces.go
+++ b/api/services/workspaces.go
@@ -254,13 +254,20 @@ func DeleteWorkspaceService(svc *Service, w http.ResponseWriter, r *http.Request
 
 	logger := zerolog.Ctx(r.Context())
 
-	// // Extract the claims to get the users KC ID
-	// claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
-	// if !ok {
-	// 	logger.Warn().Msg("Unauthorized request: missing claims")
-	// 	WriteResponse(w, http.StatusUnauthorized, nil)
-	// 	return
-	// }
+	// Extract the claims to get the users KC ID
+	claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
+	if !ok {
+		logger.Warn().Msg("Unauthorized request: missing claims")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
+
+	// Workspace Scoped tokens not authorized to delete workspace
+	if claims.Workspace != "" {
+		logger.Warn().Msg("Unauthorized request: workspace scoped token")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
 
 	// Parse the workspace ID from the URL path
 	workspaceID := mux.Vars(r)["workspace-id"]
@@ -278,9 +285,5 @@ func DeleteWorkspaceService(svc *Service, w http.ResponseWriter, r *http.Request
 	}
 
 	WriteResponse(w, http.StatusNoContent, nil)
-
-	// delete group by keycloak
-	// delete workspace by db
-	// send delete to pulsar
 
 }

--- a/cmd/consume.go
+++ b/cmd/consume.go
@@ -107,22 +107,20 @@ var consumeCmd = &cobra.Command{
 				// Discard the message if incoming status is older
 				consumer.Ack(msg)
 			}
-
 		}
-
 	},
 }
 
+// deleteWorkspace deletes a workspace from the database, Keycloak and AWS Secrets Manager
 func deleteWorkspace(wsStatus ws_manager.WorkspaceStatus) error {
 
-	//Remove workspace record from database
+	// Remove workspace record from database
 	err := workspaceDB.DeleteWorkspace(wsStatus.Name)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to delete workspace")
 		return err
 	}
 
-	// Remove Keycloak Group
 	// Get a token from keycloak so we can interact with it's API
 	err = keycloakClient.GetToken()
 	if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -53,6 +53,7 @@ var serveCmd = &cobra.Command{
 			log.Fatal().Err(err).Msg("Failed to initialize secrets manager client")
 		}
 
+		// Initialize Kubernetes client
 		k8sClient, err := initializeK8sClient()
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to initialize Kubernetes client")
@@ -87,6 +88,8 @@ var serveCmd = &cobra.Command{
 		api.HandleFunc("/workspaces/{workspace-id}", handlers.GetWorkspace(service)).Methods(http.MethodGet)
 		api.HandleFunc("/workspaces/{workspace-id}", handlers.UpdateWorkspace(service)).Methods(http.MethodPut)
 		api.HandleFunc("/workspaces/{workspace-id}", handlers.PatchWorkspace(service)).Methods(http.MethodPatch)
+		api.HandleFunc("/workspaces/{workspace-id}", handlers.DeleteWorkspace(service)).Methods(http.MethodDelete)
+
 
 		// Workspace management routes
 		api.HandleFunc("/workspaces/{workspace-id}/users", handlers.GetUsers(service)).Methods(http.MethodGet)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,10 +10,7 @@ import (
 	"github.com/EO-DataHub/eodhp-workspace-services/api/middleware"
 	"github.com/EO-DataHub/eodhp-workspace-services/api/services"
 	docs "github.com/EO-DataHub/eodhp-workspace-services/docs"
-	"github.com/EO-DataHub/eodhp-workspace-services/internal/appconfig"
 	"github.com/EO-DataHub/eodhp-workspace-services/internal/events"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
@@ -34,7 +30,7 @@ var serveCmd = &cobra.Command{
 	Short: "Run the HTTP server for handling API requests",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		// Load the config, initialize the database and set up logging
+		// Load the config, initialize the database, keycloak, AWS Secrets Manager and set up logging
 		commonSetUp()
 
 		// Initialize event publisher
@@ -43,15 +39,6 @@ var serveCmd = &cobra.Command{
 			log.Fatal().Err(err).Msg("Failed to initialize event publisher")
 		}
 		defer publisher.Close()
-
-		// Initialise KeyCloak client
-		keycloakClient := initializeKeycloakClient(appCfg.Keycloak)
-
-		// Initialize secrets manager client
-		secretsManagerClient, err := initializeSecretsManagerClient(appCfg.AWS.Region)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to initialize secrets manager client")
-		}
 
 		// Initialize Kubernetes client
 		k8sClient, err := initializeK8sClient()
@@ -89,7 +76,6 @@ var serveCmd = &cobra.Command{
 		api.HandleFunc("/workspaces/{workspace-id}", handlers.UpdateWorkspace(service)).Methods(http.MethodPut)
 		api.HandleFunc("/workspaces/{workspace-id}", handlers.PatchWorkspace(service)).Methods(http.MethodPatch)
 		api.HandleFunc("/workspaces/{workspace-id}", handlers.DeleteWorkspace(service)).Methods(http.MethodDelete)
-
 
 		// Workspace management routes
 		api.HandleFunc("/workspaces/{workspace-id}/users", handlers.GetUsers(service)).Methods(http.MethodGet)
@@ -145,26 +131,26 @@ func init() {
 
 }
 
-// InitializeKeycloakClient initializes the Keycloak client and retrieves the access token.
-func initializeKeycloakClient(kcCfg appconfig.KeycloakConfig) *services.KeycloakClient {
-	keycloakClientSecret := os.Getenv("KEYCLOAK_CLIENT_SECRET")
+// // InitializeKeycloakClient initializes the Keycloak client and retrieves the access token.
+// func initializeKeycloakClient(kcCfg appconfig.KeycloakConfig) *services.KeycloakClient {
+// 	keycloakClientSecret := os.Getenv("KEYCLOAK_CLIENT_SECRET")
 
-	// Create a new Keycloak client
-	keycloakClient := services.NewKeycloakClient(kcCfg.URL, kcCfg.ClientId, keycloakClientSecret, kcCfg.Realm)
+// 	// Create a new Keycloak client
+// 	keycloakClient := services.NewKeycloakClient(kcCfg.URL, kcCfg.ClientId, keycloakClientSecret, kcCfg.Realm)
 
-	return keycloakClient
-}
+// 	return keycloakClient
+// }
 
-// InitializeSecretsManagerClient initializes the AWS Secrets Manager client.
-func initializeSecretsManagerClient(region string) (*secretsmanager.Client, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
-	if err != nil {
-		return nil, fmt.Errorf("unable to load SDK config, %v", err)
-	}
+// // InitializeSecretsManagerClient initializes the AWS Secrets Manager client.
+// func initializeSecretsManagerClient(region string) (*secretsmanager.Client, error) {
+// 	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+// 	if err != nil {
+// 		return nil, fmt.Errorf("unable to load SDK config, %v", err)
+// 	}
 
-	svc := secretsmanager.NewFromConfig(cfg)
-	return svc, nil
-}
+// 	svc := secretsmanager.NewFromConfig(cfg)
+// 	return svc, nil
+// }
 
 func initializeK8sClient() (*kubernetes.Clientset, error) {
 	var config *rest.Config


### PR DESCRIPTION
- Made sure all endpoints are compliant with:
[https://github.com/EO-DataHub/documentation/blob/main/APIs/01.%20Overview.md#eodh-workspaces-and-accounts-api-endpoints](url)

- Added `DELETE` endpoint for workspaces (user scoped only). Once workspace is confirmed as deleted via Pulsar, we clean up remaining external resources (delete keycloak group, AWS linked-accounts, DB record)