### PR TITLE
added account confirmation/denial email to inform user

### DIFF
--- a/api/services/keycloak.go
+++ b/api/services/keycloak.go
@@ -54,7 +54,7 @@ type KeycloakClientInterface interface {
 	GetGroupMember(groupID, userID string) (*models.User, error)
 	AddMemberToGroup(userID, groupID string) error
 	RemoveMemberFromGroup(userID, groupID string) error
-	GetUserID(username string) (string, error)
+	GetUser(username string) (*models.User, error)
 	GetUserGroups(userID string) ([]string, error)
 	ExchangeToken(accessToken, scope string) (*TokenResponse, error)
 }
@@ -242,29 +242,29 @@ func (kc *KeycloakClient) RemoveMemberFromGroup(userID, groupID string) error {
 	return nil
 }
 
-// GetUserID retrieves a user ID by username from Keycloak.
-func (kc *KeycloakClient) GetUserID(username string) (string, error) {
+// GetUser retrieves a user ID by username from Keycloak.
+func (kc *KeycloakClient) GetUser(username string) (*models.User, error) {
 	url := fmt.Sprintf("%s/admin/realms/%s/users?username=%s", kc.BaseURL, kc.Realm, username)
 
 	respBody, statusCode, err := kc.makeRequest(http.MethodGet, url, "application/json", nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch user by username: %w", err)
+		return nil, fmt.Errorf("failed to fetch user by username: %w", err)
 	}
 
 	if statusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to fetch user, status: %d", statusCode)
+		return nil, fmt.Errorf("failed to fetch user, status: %d", statusCode)
 	}
 
 	var users []models.User
 	if err := json.Unmarshal(respBody, &users); err != nil {
-		return "", fmt.Errorf("failed to decode response: %w", err)
+		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
 	if len(users) == 0 {
-		return "", fmt.Errorf("user '%s' not found", username)
+		return nil, fmt.Errorf("user '%s' not found", username)
 	}
 
-	return users[0].ID, nil
+	return &users[0], nil
 }
 
 // GetUserGroups retrieves a list of group names that a user is a member of.

--- a/api/services/mocks.go
+++ b/api/services/mocks.go
@@ -189,9 +189,9 @@ func (m *MockKeycloakClient) GetGroupMember(groupID, userID string) (*models.Use
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockKeycloakClient) GetUserID(username string) (string, error) {
+func (m *MockKeycloakClient) GetUser(username string) (*models.User, error) {
 	args := m.Called(username)
-	return args.String(0), args.Error(1)
+	return args.Get(0).(*models.User), args.Error(1)
 }
 
 func (m *MockKeycloakClient) GetUserGroups(userID string) ([]string, error) {

--- a/api/services/users.go
+++ b/api/services/users.go
@@ -65,7 +65,6 @@ func (svc *WorkspaceService) GetUsersService(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	logger.Info().Int("user_count", len(members)).Msg("Successfully retrieved workspace users")
 	WriteResponse(w, http.StatusOK, members)
 }
 
@@ -117,7 +116,7 @@ func (svc *WorkspaceService) GetUserService(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	userID, err := svc.KC.GetUserID(username)
+	user, err := svc.KC.GetUser(username)
 	if err != nil {
 		logger.Warn().Err(err).Str("username", username).Msg("User ID not found")
 		WriteResponse(w, http.StatusNotFound, err.Error())
@@ -125,15 +124,14 @@ func (svc *WorkspaceService) GetUserService(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Get the members of the group
-	member, err := svc.KC.GetGroupMember(group.ID, userID)
+	member, err := svc.KC.GetGroupMember(group.ID, user.ID)
 
 	if err != nil {
-		logger.Error().Err(err).Str("group_id", group.ID).Str("user_id", userID).Msg("Failed to retrieve user membership")
+		logger.Error().Err(err).Str("group_id", group.ID).Str("user_id", user.ID).Msg("Failed to retrieve user membership")
 		WriteResponse(w, http.StatusInternalServerError, nil)
 		return
 	}
 
-	logger.Info().Str("user_id", userID).Msg("Successfully retrieved workspace user")
 	WriteResponse(w, http.StatusOK, member)
 }
 
@@ -185,7 +183,7 @@ func (svc *WorkspaceService) AddUserService(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	userID, err := svc.KC.GetUserID(username)
+	user, err := svc.KC.GetUser(username)
 	if err != nil {
 		logger.Warn().Err(err).Str("username", username).Msg("User ID not found")
 		WriteResponse(w, http.StatusNotFound, err.Error())
@@ -193,9 +191,9 @@ func (svc *WorkspaceService) AddUserService(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Add the user to the group in Keycloak
-	err = svc.KC.AddMemberToGroup(userID, group.ID)
+	err = svc.KC.AddMemberToGroup(user.ID, group.ID)
 	if err != nil {
-		logger.Error().Err(err).Str("user_id", userID).Str("group_id", group.ID).Msg("Failed to add user to group")
+		logger.Error().Err(err).Str("user_id", user.ID).Str("group_id", group.ID).Msg("Failed to add user to group")
 		WriteResponse(w, http.StatusInternalServerError, nil)
 		return
 	}
@@ -267,7 +265,7 @@ func (svc *WorkspaceService) RemoveUserService(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	userID, err := svc.KC.GetUserID(username)
+	user, err := svc.KC.GetUser(username)
 	if err != nil {
 		logger.Warn().Err(err).Str("username", username).Msg("User ID not found")
 		WriteResponse(w, http.StatusNotFound, err.Error())
@@ -275,10 +273,10 @@ func (svc *WorkspaceService) RemoveUserService(w http.ResponseWriter, r *http.Re
 	}
 
 	// Remove the user from the group in Keycloak
-	err = svc.KC.RemoveMemberFromGroup(userID, group.ID)
+	err = svc.KC.RemoveMemberFromGroup(user.ID, group.ID)
 
 	if err != nil {
-		logger.Error().Err(err).Str("user_id", userID).Str("group_id", group.ID).Msg("Failed to remove user from group")
+		logger.Error().Err(err).Str("user_id", user.ID).Str("group_id", group.ID).Msg("Failed to remove user from group")
 		WriteResponse(w, http.StatusInternalServerError, nil)
 		return
 	}

--- a/api/services/utils.go
+++ b/api/services/utils.go
@@ -64,6 +64,11 @@ func IsDNSCompatible(name string) bool {
 // isUserWorkspaceAuthorized checks if a user is authorized to access information in a workspace
 func isUserWorkspaceAuthorized(svc db.WorkspaceDBInterface, claims authn.Claims, workspace string, mustBeAccountOwner bool) (bool, error) {
 
+	// hub_admin role is a superuser role
+	if HasRole(claims.RealmAccess.Roles, "hub_admin") {
+		return true, nil
+	}
+
 	if claims.Username == "service-account-eodh-workspaces" {
 		return true, nil
 	}
@@ -98,7 +103,6 @@ func isUserWorkspaceAuthorized(svc db.WorkspaceDBInterface, claims authn.Claims,
 	// Return false if the user is not a member of the workspace or an account owner
 	return false, nil
 }
-
 
 func makeHTTPRequest(method, url string, headers map[string]string, body []byte) ([]byte, error) {
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,6 +82,7 @@ var serveCmd = &cobra.Command{
 			Config:         appCfg,
 			DB:             workspaceDB,
 			AWSEmailClient: awsclient.NewSESClient(awsCfg),
+			KC:             keycloakClient,
 		}
 		accountRouter := api.PathPrefix("/accounts").Subrouter()
 		accountRouter.Use(middleware.DenyWorkspaceScopedTokens)


### PR DESCRIPTION
- Once a `hub_admin` approves/denies a billing account request, the user that submitted the form will receive an email of the administrative output (approved/denied).
- Added a check where if a user is `hub_admin` they can bypass some authorization checks on workspaces

Tested on `dev` by going through the whole workflow of creating a billing account, approving/denying the request (via email link) and the end user (me) getting a receipt of this judgement.

I have also requested to get out of SandBox mode in AWS SES service so that we do not have to verify email identities in the console in order to use this service - so that any user address stored in keycloak can be used from our service account. Should be straight forward. I'll hear back from AWS within 24hr