### PR TITLE
refactored GET workspaces to accomodate ownership

### DIFF
--- a/api/services/mocks.go
+++ b/api/services/mocks.go
@@ -98,6 +98,11 @@ func (m *MockWorkspaceDB) GetUserWorkspaces(memberGroups []string) ([]ws_manager
 	return args.Get(0).([]ws_manager.WorkspaceSettings), args.Error(1)
 }
 
+func (m *MockWorkspaceDB) GetOwnedWorkspaces(username string) ([]ws_manager.WorkspaceSettings, error) {
+	args := m.Called(username)
+	return args.Get(0).([]ws_manager.WorkspaceSettings), args.Error(1)
+}
+
 func (m *MockWorkspaceDB) CheckWorkspaceExists(name string) (bool, error) {
 	args := m.Called(name)
 	return args.Bool(0), args.Error(1)

--- a/api/services/workspaces.go
+++ b/api/services/workspaces.go
@@ -38,47 +38,47 @@ func (svc *WorkspaceService) GetWorkspacesService(w http.ResponseWriter, r *http
 
 	_, workspacesOwned := r.URL.Query()["owned"]
 
-	// Retrieve groups the user is a member of
-	memberGroups, err := svc.KC.GetUserGroups(claims.Subject)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", claims.Subject).Msg("Failed to retrieve user groups")
-		WriteResponse(w, http.StatusInternalServerError, nil)
-	}
+	var workspaces []ws_manager.WorkspaceSettings
+	var err error
+	if workspacesOwned {
+		// Retrieve workspaces owned by the user
+		workspaces, err = svc.DB.GetOwnedWorkspaces(claims.Username)
+		if err != nil {
+			logger.Error().Err(err).Msg("Database error retrieving workspaces")
+			WriteResponse(w, http.StatusInternalServerError, nil)
+			return
+		}
+	} else {
 
-	// Retrieve workspaces assigned to these groups
-	workspaces, err := svc.DB.GetUserWorkspaces(memberGroups)
-	if err != nil {
-		logger.Error().Err(err).Msg("Database error retrieving workspaces")
-		WriteResponse(w, http.StatusInternalServerError, nil)
-		return
+		// Retrieve groups the user is a member of
+		memberGroups, err := svc.KC.GetUserGroups(claims.Subject)
+		if err != nil {
+			logger.Error().Err(err).Str("user_id", claims.Subject).Msg("Failed to retrieve user groups")
+			WriteResponse(w, http.StatusInternalServerError, nil)
+		}
+
+		// Retrieve workspaces assigned to these groups
+		workspaces, err = svc.DB.GetUserWorkspaces(memberGroups)
+		if err != nil {
+			logger.Error().Err(err).Msg("Database error retrieving workspaces")
+			WriteResponse(w, http.StatusInternalServerError, nil)
+			return
+		}
 	}
 
 	var result []ws_manager.WorkspaceSettings
 
 	for _, ws := range workspaces {
 
-		// If workspace scoped cliam and the workspace name does not match, skip it
+		// If workspace scoped claim and the workspace name does not match, skip it
 		if claims.Workspace != "" && ws.Name != claims.Workspace {
 			continue
 		}
 
-		// Check if user requests owned workspaces only
-		if workspacesOwned {
-			isOwner, err := svc.DB.IsUserAccountOwner(claims.Username, ws.Name)
-			if err != nil {
-				logger.Error().Err(err).Str("workspace_id", ws.Name).Msg("Database error checking workspace ownership")
-				WriteResponse(w, http.StatusInternalServerError, nil)
-				return
-			}
-
-			if isOwner {
-				result = append(result, ws)
-			}
-		} else {
-			result = append(result, ws)
-		}
+		result = append(result, ws)
 	}
 
+	// If workspace scoped claim and no matching workspaces, return unauthorized
 	if claims.Workspace != "" && len(result) == 0 {
 		WriteResponse(w, http.StatusUnauthorized, nil)
 		return

--- a/db/db.go
+++ b/db/db.go
@@ -34,6 +34,7 @@ type WorkspaceDBInterface interface {
 	UpdateAccountStatus(token, accountID, status string) error
 	GetWorkspace(workspace_name string) (*ws_manager.WorkspaceSettings, error)
 	GetUserWorkspaces(memberGroups []string) ([]ws_manager.WorkspaceSettings, error)
+	GetOwnedWorkspaces(username string) ([]ws_manager.WorkspaceSettings, error)
 	CheckWorkspaceExists(name string) (bool, error)
 	UpdateWorkspaceStatus(status ws_manager.WorkspaceStatus) error
 	DeleteWorkspace(workspaceName string) error


### PR DESCRIPTION
Refactored `GET /api/workspaces` to add a query param `?owned`

This endpoint is used as part of a new token scope `workspaces-owned` so that it can utilized across microservices