### PR TITLE
added planet validation endpoint

### DIFF
--- a/api/handlers/linked-accounts.go
+++ b/api/handlers/linked-accounts.go
@@ -40,3 +40,13 @@ func ValidateAirbusLinkedAccount(svc *services.LinkedAccountService) http.Handle
 		svc.ValidateAirbusLinkedAccountService(w, r)
 	}
 }
+
+// ValidatePlanetLinkedAccount handles HTTP requests for validating an Planet linked account.
+func ValidatePlanetLinkedAccount(svc *services.LinkedAccountService) http.HandlerFunc {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		svc.ValidatePlanetLinkedAccountService(w, r)
+	}
+}
+

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -117,6 +117,7 @@ var serveCmd = &cobra.Command{
 		api.HandleFunc("/workspaces/{workspace-id}/linked-accounts", handlers.GetLinkedAccounts(linkedAccountService)).Methods(http.MethodGet)
 		api.HandleFunc("/workspaces/{workspace-id}/linked-accounts/{provider}", handlers.DeleteLinkedAccount(linkedAccountService)).Methods(http.MethodDelete)
 		api.HandleFunc("/workspaces/{workspace-id}/linked-accounts/airbus/validate", handlers.ValidateAirbusLinkedAccount(linkedAccountService)).Methods(http.MethodPost)
+		api.HandleFunc("/workspaces/{workspace-id}/linked-accounts/planet/validate", handlers.ValidatePlanetLinkedAccount(linkedAccountService)).Methods(http.MethodPost)
 
 		// Data Loader routes
 		api.HandleFunc("/workspaces/{workspace-id}/data-loader", handlers.AddFileDataLoader(appCfg, sts_client, *keycloakClient)).Methods(http.MethodPost)

--- a/internal/appconfig/appconfig.go
+++ b/internal/appconfig/appconfig.go
@@ -70,8 +70,13 @@ type AirbusProviderConfig struct {
 	SARContractsURL     string `yaml:"sar_contracts_url"`
 }
 
+type PlanetProviderConfig struct {
+	ValidationURL string `yaml:"validation_url"`
+}
+
 type ProvidersConfig struct {
 	Airbus AirbusProviderConfig `yaml:"airbus"`
+	Planet PlanetProviderConfig `yaml:"planet"`
 }
 
 // LoadConfig loads and parses the configuration from a given file path


### PR DESCRIPTION
- Added validation endpoint for Planet (similar to Airbus).
- Calls an internal Planet API endpoint (a simple GET to `/subscriptions`). 
- If `200` its valid.