### PR TITLE
data-loader delete s3 objects

### DIFF
--- a/api/handlers/data-loader.go
+++ b/api/handlers/data-loader.go
@@ -13,13 +13,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 )
 
-type DataLoaderPayload struct {
+type DataLoaderFileUpload struct {
 	FileContent string `json:"fileContent"`
 	FileName    string `json:"fileName"`
+}
+
+type DataLoaderFilesDelete struct {
+	Keys []string `json:"keys"`
 }
 
 // AddFileDataLoader is a handler that uploads a file to S3
@@ -34,7 +39,7 @@ func AddFileDataLoader(appCfg *appconfig.Config, c STSClient, k services.Keycloa
 		workspaceID := mux.Vars(r)["workspace-id"]
 
 		// Parse the payload
-		var payload DataLoaderPayload
+		var payload DataLoaderFileUpload
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Error decoding payload")
 			http.Error(w, fmt.Sprintf("Error decoding payload: %v", err), http.StatusBadRequest)
@@ -95,5 +100,97 @@ func AddFileDataLoader(appCfg *appconfig.Config, c STSClient, k services.Keycloa
 		})
 		logger.Info().Str("bucket", bucket).Str("key", objectKey).Msg("File uploaded to S3")
 
+	}
+}
+
+// DeleteFileDataLoader is a handler that deletes files from S3
+func DeleteFileDataLoader(appCfg *appconfig.Config, c STSClient, k services.KeycloakClient) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		logger := zerolog.Ctx(ctx).With().Str("role arn", appCfg.AWS.S3.RoleArn).Logger()
+
+		workspaceID := mux.Vars(r)["workspace-id"]
+		bucket := appCfg.AWS.S3.Bucket
+
+		var payload DataLoaderFilesDelete
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Error decoding payload")
+			http.Error(w, fmt.Sprintf("Error decoding payload: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		if len(payload.Keys) == 0 {
+			http.Error(w, "No keys provided for deletion", http.StatusBadRequest)
+			return
+		}
+
+		// Get temporary credentials
+		creds, err := GetS3Credentials(appCfg.AWS.S3.RoleArn, c, k, r)
+		if err != nil {
+			var status int
+			if httpErr, ok := err.(*services.HTTPError); ok {
+				status = httpErr.Status
+			} else {
+				status = http.StatusInternalServerError
+			}
+			http.Error(w, err.Error(), status)
+			return
+		}
+
+		cfg, err := config.LoadDefaultConfig(ctx,
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+				creds.AccessKeyId,
+				creds.SecretAccessKey,
+				creds.SessionToken,
+			)),
+		)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to load AWS config")
+			http.Error(w, "Failed to configure S3 client", http.StatusInternalServerError)
+			return
+		}
+
+		s3Client := awsclient.NewS3Client(cfg)
+
+		var objects []s3types.ObjectIdentifier
+		for _, key := range payload.Keys {
+			objects = append(objects, s3types.ObjectIdentifier{Key: aws.String(key)})
+		}
+
+		output, err := s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(bucket),
+			Delete: &s3types.Delete{
+				Objects: objects,
+				Quiet:   aws.Bool(false),
+			},
+		})
+		if err != nil {
+			logger.Error().Err(err).Msg("DeleteObjects call failed")
+			http.Error(w, "Failed to delete objects", http.StatusInternalServerError)
+			return
+		}
+
+		if len(output.Errors) > 0 {
+			for _, delErr := range output.Errors {
+				logger.Error().
+					Str("key", aws.ToString(delErr.Key)).
+					Str("code", aws.ToString(delErr.Code)).
+					Str("message", aws.ToString(delErr.Message)).
+					Msg("S3 DeleteObjects error")
+			}
+			http.Error(w, "Some keys failed to delete", http.StatusConflict)
+			return
+		}
+
+		logger.Info().
+			Str("bucket", bucket).
+			Int("deleted_count", len(output.Deleted)).
+			Msg("Files deleted from S3")
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": fmt.Sprintf("Successfully deleted %d files from %s", len(output.Deleted), bucket),
+		})
 	}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -121,6 +121,7 @@ var serveCmd = &cobra.Command{
 
 		// Data Loader routes
 		api.HandleFunc("/workspaces/{workspace-id}/data-loader", handlers.AddFileDataLoader(appCfg, sts_client, *keycloakClient)).Methods(http.MethodPost)
+		api.HandleFunc("/workspaces/{workspace-id}/data-loader", handlers.DeleteFileDataLoader(appCfg, sts_client, *keycloakClient)).Methods(http.MethodDelete)
 
 		// Docs
 		docs.SwaggerInfo.Host = appCfg.Host


### PR DESCRIPTION
- Added `DELETE` endpoint to remove files from a users S3 workspace via data loader
- Tested on `dev3`

Example body:

```json
{
   "keys": [
      "jlangstone-tpzuk/commercial-data/item.json"
   ]
}
```

The bucket is provided from the config map