### PR TITLE
Bugfix/eodhp 1327

### DIFF
--- a/api/handlers/linked-accounts.go
+++ b/api/handlers/linked-accounts.go
@@ -11,6 +11,13 @@ func CreateLinkedAccount(svc *services.LinkedAccountService) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
+		// Get a token from keycloak so we can interact with it's API
+		err := svc.KC.GetToken()
+		if err != nil {
+			http.Error(w, "Authentication failed.", http.StatusInternalServerError)
+			return
+		}
+
 		svc.CreateLinkedAccountService(w, r)
 	}
 }
@@ -19,6 +26,14 @@ func CreateLinkedAccount(svc *services.LinkedAccountService) http.HandlerFunc {
 func GetLinkedAccounts(svc *services.LinkedAccountService) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
+
+		// Get a token from keycloak so we can interact with it's API
+		err := svc.KC.GetToken()
+		if err != nil {
+			http.Error(w, "Authentication failed.", http.StatusInternalServerError)
+			return
+		}
+
 		svc.GetLinkedAccounts(w, r)
 	}
 }
@@ -27,6 +42,13 @@ func GetLinkedAccounts(svc *services.LinkedAccountService) http.HandlerFunc {
 func DeleteLinkedAccount(svc *services.LinkedAccountService) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
+
+		// Get a token from keycloak so we can interact with it's API
+		err := svc.KC.GetToken()
+		if err != nil {
+			http.Error(w, "Authentication failed.", http.StatusInternalServerError)
+			return
+		}
 
 		svc.DeleteLinkedAccountService(w, r)
 	}
@@ -49,4 +71,3 @@ func ValidatePlanetLinkedAccount(svc *services.LinkedAccountService) http.Handle
 		svc.ValidatePlanetLinkedAccountService(w, r)
 	}
 }
-

--- a/api/services/linked-accounts.go
+++ b/api/services/linked-accounts.go
@@ -52,6 +52,7 @@ type LinkedAccountService struct {
 	DB             *db.WorkspaceDB
 	SecretsManager *secretsmanager.Client
 	K8sClient      *kubernetes.Clientset
+	KC             KeycloakClientInterface
 }
 
 // Payload represents the expected JSON structure
@@ -90,7 +91,7 @@ func (svc *LinkedAccountService) GetLinkedAccounts(w http.ResponseWriter, r *htt
 	workspaceID := mux.Vars(r)["workspace-id"]
 
 	// Check if the user can access the workspace
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, false)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, false)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)
@@ -138,7 +139,7 @@ func (svc *LinkedAccountService) DeleteLinkedAccountService(w http.ResponseWrite
 	namespace := "ws-" + workspaceID
 
 	// Check if the user is the account owner
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, true)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, true)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)
@@ -194,7 +195,7 @@ func (svc *LinkedAccountService) CreateLinkedAccountService(w http.ResponseWrite
 	namespace := "ws-" + workspaceID
 
 	// Check if the user is the account owner
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, true)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, true)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)
@@ -288,7 +289,7 @@ func (svc *LinkedAccountService) ValidateAirbusLinkedAccountService(w http.Respo
 	workspaceID := mux.Vars(r)["workspace-id"]
 
 	// Check if the user is the account owner
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, true)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, true)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)
@@ -373,7 +374,7 @@ func (svc *LinkedAccountService) ValidatePlanetLinkedAccountService(w http.Respo
 	workspaceID := mux.Vars(r)["workspace-id"]
 
 	// Check if the user is the account owner
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, true)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, true)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)

--- a/api/services/users.go
+++ b/api/services/users.go
@@ -26,7 +26,7 @@ func (svc *WorkspaceService) GetUsersService(w http.ResponseWriter, r *http.Requ
 	workspaceID := mux.Vars(r)["workspace-id"]
 
 	// Check if the user can access the workspace
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, false)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, false)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)
@@ -86,7 +86,7 @@ func (svc *WorkspaceService) GetUserService(w http.ResponseWriter, r *http.Reque
 	username := mux.Vars(r)["username"]
 
 	// Check if the user can access the workspace
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, false)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, false)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)
@@ -153,7 +153,7 @@ func (svc *WorkspaceService) AddUserService(w http.ResponseWriter, r *http.Reque
 	username := mux.Vars(r)["username"]
 
 	// Only account owners can remove users from a workspace
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, true)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, true)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)
@@ -220,7 +220,7 @@ func (svc *WorkspaceService) RemoveUserService(w http.ResponseWriter, r *http.Re
 	username := mux.Vars(r)["username"]
 
 	// Only account owners can remove users from a workspace
-	authorized, err := isUserWorkspaceAuthorized(svc.DB, claims, workspaceID, true)
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, true)
 	if err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
 		WriteResponse(w, http.StatusInternalServerError, nil)

--- a/api/services/utils.go
+++ b/api/services/utils.go
@@ -62,7 +62,7 @@ func IsDNSCompatible(name string) bool {
 }
 
 // isUserWorkspaceAuthorized checks if a user is authorized to access information in a workspace
-func isUserWorkspaceAuthorized(svc db.WorkspaceDBInterface, claims authn.Claims, workspace string, mustBeAccountOwner bool) (bool, error) {
+func isUserWorkspaceAuthorized(db db.WorkspaceDBInterface, kc KeycloakClientInterface, claims authn.Claims, workspace string, mustBeAccountOwner bool) (bool, error) {
 
 	// hub_admin role is a superuser role
 	if HasRole(claims.RealmAccess.Roles, "hub_admin") {
@@ -73,12 +73,17 @@ func isUserWorkspaceAuthorized(svc db.WorkspaceDBInterface, claims authn.Claims,
 		return true, nil
 	}
 
+	// Get the groups from keycloak associated with the user
+	memberGroups, err := kc.GetUserGroups(claims.Subject)
+	if err != nil {
+	}
+
 	// Check if the user is an account owner
 	if mustBeAccountOwner {
-		if isMemberGroupAuthorized(workspace, claims.MemberGroups) {
+		if isMemberGroupAuthorized(workspace, memberGroups) {
 
 			// Do they own the workspace
-			isAccountOwner, err := svc.IsUserAccountOwner(claims.Username, workspace)
+			isAccountOwner, err := db.IsUserAccountOwner(claims.Username, workspace)
 
 			// Check for errors
 			if err != nil {

--- a/api/services/utils.go
+++ b/api/services/utils.go
@@ -76,6 +76,7 @@ func isUserWorkspaceAuthorized(db db.WorkspaceDBInterface, kc KeycloakClientInte
 	// Get the groups from keycloak associated with the user
 	memberGroups, err := kc.GetUserGroups(claims.Subject)
 	if err != nil {
+		return false, err
 	}
 
 	// Check if the user is an account owner
@@ -101,7 +102,7 @@ func isUserWorkspaceAuthorized(db db.WorkspaceDBInterface, kc KeycloakClientInte
 	}
 
 	// If the user is not an account owner, check if they are a member of the workspace
-	if isMemberGroupAuthorized(workspace, claims.MemberGroups) {
+	if isMemberGroupAuthorized(workspace, memberGroups) {
 		return true, nil
 	}
 

--- a/api/services/workspaces.go
+++ b/api/services/workspaces.go
@@ -119,8 +119,15 @@ func (svc *WorkspaceService) GetWorkspaceService(w http.ResponseWriter, r *http.
 		return
 	}
 
+	// Get the groups from keycloak associated with the user
+	memberGroups, err := svc.KC.GetUserGroups(claims.Subject)
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", claims.Subject).Msg("Failed to retrieve user groups")
+		WriteResponse(w, http.StatusInternalServerError, nil)
+	}
+
 	// Check if the account owner matches any of the claims member groups
-	if !isMemberGroupAuthorized(workspace.MemberGroup, claims.MemberGroups) {
+	if !isMemberGroupAuthorized(workspace.MemberGroup, memberGroups) {
 		logger.Warn().Str("workspace_id", workspaceID).Str("user", claims.Username).Msg("Access denied: user not in authorized groups")
 		WriteResponse(w, http.StatusForbidden, nil)
 		return

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -112,6 +112,7 @@ var serveCmd = &cobra.Command{
 			DB:             workspaceDB,
 			SecretsManager: secretsManagerClient,
 			K8sClient:      k8sClient,
+			KC:             keycloakClient,
 		}
 		api.HandleFunc("/workspaces/{workspace-id}/linked-accounts", handlers.CreateLinkedAccount(linkedAccountService)).Methods(http.MethodPost)
 		api.HandleFunc("/workspaces/{workspace-id}/linked-accounts", handlers.GetLinkedAccounts(linkedAccountService)).Methods(http.MethodGet)

--- a/internal/authn/utils.go
+++ b/internal/authn/utils.go
@@ -17,8 +17,7 @@ type Claims struct {
 	RealmAccess struct {
 		Roles []string `json:"roles"`
 	} `json:"realm_access"`
-	Workspace    string   `json:"workspace"`
-	MemberGroups []string `json:"member_groups"`
+	Workspace string `json:"workspace"`
 }
 
 func ParseClaims(tokenStr string) (Claims, error) {


### PR DESCRIPTION
- When a user creates a workspace they will immediately have authz access to said workspace (including adding/removing members and linking commerial accounts)
- Bug was that we were using the `MemberGroups` within the claims to determine authz but those claims will not refresh within the session straight away, so instead we get the groups the user is in directly from keycloak API.
- Removed `MemberGroups` completely from `claims` struct - no longer needed

This PR will have resolved multiple bugs in one go.

It was raised in this issue - https://github.com/EO-DataHub/platform-bugs/issues/94#issuecomment-2897636507