### PR TITLE
disable workspace accessability after 'delete'

### DIFF
--- a/api/services/mocks.go
+++ b/api/services/mocks.go
@@ -113,7 +113,7 @@ func (m *MockWorkspaceDB) UpdateWorkspaceStatus(status ws_manager.WorkspaceStatu
 	return args.Error(0)
 }
 
-func (m *MockWorkspaceDB) DeleteWorkspace(workspaceName string) error {
+func (m *MockWorkspaceDB) DisableWorkspace(workspaceName string) error {
 	args := m.Called(workspaceName)
 	return args.Error(0)
 }

--- a/cmd/consume.go
+++ b/cmd/consume.go
@@ -111,11 +111,12 @@ var consumeCmd = &cobra.Command{
 	},
 }
 
-// deleteWorkspace deletes a workspace from the database, Keycloak and AWS Secrets Manager
+// deleteWorkspace deletes a workspace by setting its status to 'Unavailable' in the database,
+// removing its Keycloak group, and deleting any lingering secrets in AWS Secrets Manager.
 func deleteWorkspace(wsStatus ws_manager.WorkspaceStatus) error {
 
-	// Remove workspace record from database
-	err := workspaceDB.DeleteWorkspace(wsStatus.Name)
+	// Set the workspace as 'Unavailable' in the database
+	err := workspaceDB.DisableWorkspace(wsStatus.Name)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to delete workspace")
 		return err

--- a/db/db.go
+++ b/db/db.go
@@ -37,7 +37,7 @@ type WorkspaceDBInterface interface {
 	GetOwnedWorkspaces(username string) ([]ws_manager.WorkspaceSettings, error)
 	CheckWorkspaceExists(name string) (bool, error)
 	UpdateWorkspaceStatus(status ws_manager.WorkspaceStatus) error
-	DeleteWorkspace(workspaceName string) error
+	DisableWorkspace(workspaceName string) error
 	CreateWorkspace(req *ws_manager.WorkspaceSettings) (*sql.Tx, error)
 	CommitTransaction(tx *sql.Tx) error
 }


### PR DESCRIPTION
I created a new ticket based on the discussion on the warranty bugs meeting yesterday:

https://telespazio-uk.atlassian.net/browse/EODHP-1391

Specifically it allows 'deleted' workspaces to remain having a presence within the ecosystem but with an 'Unavailable' status attached to it (all resources/data associated with it are actually deleted)

Workspace UI will also now handle the 409 errors explicitly (rather than a generic error) and present to the users that the workspace name is not available and that they should choose another name.

This allows us to fulfill the objective of workspace names not allowed to be 'recycled'.
