### PR TITLE
Fix/s3 credentials before multipart read

### DIFF
--- a/api/services/files.go
+++ b/api/services/files.go
@@ -11,6 +11,7 @@ import (
 	"github.com/EO-DataHub/eodhp-workspace-services/db"
 	"github.com/EO-DataHub/eodhp-workspace-services/internal/appconfig"
 	"github.com/EO-DataHub/eodhp-workspace-services/internal/authn"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
@@ -183,6 +184,24 @@ func (svc *FileService) UploadFilesService(w http.ResponseWriter, r *http.Reques
 	// Propagate the request context so downstream I/O is canceled on client disconnect/timeout.
 	ctx := r.Context()
 
+	var items []FileItem
+	wantObject, _, err := resolveStoreSelection(storeType, false)
+	if err != nil {
+		WriteResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Resolve S3 credentials before reading the request body so the JWT is
+	// still valid. ParseMultipartForm below can take minutes for large files.
+	var s3Client *s3.Client
+	if wantObject {
+		s3Client, err = svc.newS3Client(r)
+		if err != nil {
+			WriteResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
 	if err := r.ParseMultipartForm(svc.maxUploadFormMemoryBytes()); err != nil {
 		WriteResponse(w, http.StatusBadRequest, "invalid multipart form data")
 		return
@@ -193,13 +212,6 @@ func (svc *FileService) UploadFilesService(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	var items []FileItem
-	wantObject, _, err := resolveStoreSelection(storeType, false)
-	if err != nil {
-		WriteResponse(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
 	if wantObject {
 		objectStores, _ := collectStores(workspace)
 		objectStore, err := selectObjectStore(objectStores)
@@ -207,7 +219,7 @@ func (svc *FileService) UploadFilesService(w http.ResponseWriter, r *http.Reques
 			WriteResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		uploaded, err := svc.uploadObjectStoreFiles(r, objectStore, files)
+		uploaded, err := svc.uploadObjectStoreFiles(r, s3Client, objectStore, files)
 		if err != nil {
 			WriteResponse(w, http.StatusInternalServerError, err.Error())
 			return

--- a/api/services/files_object.go
+++ b/api/services/files_object.go
@@ -49,14 +49,9 @@ func (svc *FileService) listObjectStoreItems(r *http.Request, stores []ws_manage
 }
 
 // uploadObjectStoreFiles uploads multipart files to the object store.
-func (svc *FileService) uploadObjectStoreFiles(r *http.Request, store ws_manager.ObjectStore, files []*multipart.FileHeader) ([]FileItem, error) {
+func (svc *FileService) uploadObjectStoreFiles(r *http.Request, s3Client *s3.Client, store ws_manager.ObjectStore, files []*multipart.FileHeader) ([]FileItem, error) {
 	if store.Bucket == "" || store.Prefix == "" {
 		return nil, fmt.Errorf("object store not provisioned")
-	}
-
-	s3Client, err := svc.newS3Client(r)
-	if err != nil {
-		return nil, err
 	}
 
 	var items []FileItem

--- a/api/services/files_object_test.go
+++ b/api/services/files_object_test.go
@@ -165,7 +165,7 @@ func TestObjectStoreMethodsProvisioningValidation(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, status)
 	require.EqualError(t, err, "object store not provisioned")
 
-	_, err = svc.uploadObjectStoreFiles(req, ws_manager.ObjectStore{}, []*multipart.FileHeader{})
+	_, err = svc.uploadObjectStoreFiles(req, nil, ws_manager.ObjectStore{}, []*multipart.FileHeader{})
 	require.EqualError(t, err, "object store not provisioned")
 
 	_, _, err = svc.deleteObjectStoreFiles(req, ws_manager.ObjectStore{}, []string{"a.tif"})
@@ -213,7 +213,7 @@ func TestObjectStorePathValidationWithoutS3Call(t *testing.T) {
 	files := []*multipart.FileHeader{
 		{Filename: "bad/name.tif"},
 	}
-	_, err := svc.uploadObjectStoreFiles(req, ws_manager.ObjectStore{
+	_, err := svc.uploadObjectStoreFiles(req, nil, ws_manager.ObjectStore{
 		Bucket: "bucket-1",
 		Prefix: "workspace/ws-1",
 	}, files)


### PR DESCRIPTION
## Summary

- Fixes 500 errors on object store uploads larger than ~1 GB
- Root cause: `AssumeRoleWithWebIdentity` was called after `ParseMultipartForm` buffered the full request body, by which time the short-lived Keycloak JWT had expired
- Fix: call `newS3Client` before `ParseMultipartForm` so credentials are exchanged while the JWT is still valid; pass the pre-built `*s3.Client` into `uploadObjectStoreFiles`
- STS session lifetime is the AWS default of 1 hour, covering any upload that completes within that window

## Limitation

Uploads taking longer than 1 hour will still fail when the STS session
expires mid-transfer. The long-term fix is presigned S3 URLs (tracked
separately).

## Test plan

- [ ] Upload a file < 20 MB and confirm no regression
- [ ] Upload a file > 1 GB and confirm it completes without a 500
