### PR TITLE
feat: add presigned S3 upload URL endpoint

### DIFF
--- a/api/handlers/files.go
+++ b/api/handlers/files.go
@@ -37,7 +37,7 @@ func GetWorkspaceFiles(svc *services.FileService) http.HandlerFunc {
 // @Security BearerAuth
 // @Produce json
 // @Param workspace-id path string true "Workspace ID"
-// @Param file query string true "Filename to upload"
+// @Param file query string true "File path within the workspace"
 // @Param size query integer true "File size in bytes"
 // @Success 200 {object} services.FileUploadURLResponse
 // @Failure 400 {object} string

--- a/api/handlers/files.go
+++ b/api/handlers/files.go
@@ -31,6 +31,30 @@ func GetWorkspaceFiles(svc *services.FileService) http.HandlerFunc {
 	}
 }
 
+// @Summary Get a presigned upload URL for the workspace object store
+// @Description Returns a presigned S3 PutObject URL. The client uploads the file directly to S3 using the returned URL, bypassing this service entirely for the data transfer.
+// @Tags Workspace Files Management
+// @Security BearerAuth
+// @Produce json
+// @Param workspace-id path string true "Workspace ID"
+// @Param filename query string true "Filename to upload"
+// @Success 200 {object} services.FileUploadURLResponse
+// @Failure 400 {object} string
+// @Failure 401 {object} string
+// @Failure 403 {object} string
+// @Failure 404 {object} string
+// @Failure 500 {object} string
+// @Router /workspaces/{workspace-id}/files/object/upload-url [get]
+func GetWorkspaceObjectFileUploadURL(svc *services.FileService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !ensureKeycloakToken(w, svc.KC) {
+			return
+		}
+
+		svc.GetUploadURLService(w, r)
+	}
+}
+
 // @Summary Upload files to the workspace object store
 // @Description Upload files to the workspace object store.
 // @Tags Workspace Files Management

--- a/api/handlers/files.go
+++ b/api/handlers/files.go
@@ -37,7 +37,8 @@ func GetWorkspaceFiles(svc *services.FileService) http.HandlerFunc {
 // @Security BearerAuth
 // @Produce json
 // @Param workspace-id path string true "Workspace ID"
-// @Param filename query string true "Filename to upload"
+// @Param file query string true "Filename to upload"
+// @Param size query integer true "File size in bytes"
 // @Success 200 {object} services.FileUploadURLResponse
 // @Failure 400 {object} string
 // @Failure 401 {object} string

--- a/api/services/files.go
+++ b/api/services/files.go
@@ -73,6 +73,12 @@ type FileMetadataResponse struct {
 	Item      FileItem `json:"item"`
 }
 
+type FileUploadURLResponse struct {
+	Workspace string `json:"workspace"`
+	URL       string `json:"url"`
+	FileName  string `json:"fileName"`
+}
+
 // resolveAuthorizedWorkspace validates access to the requested workspace and loads its settings.
 func (svc *FileService) resolveAuthorizedWorkspace(w http.ResponseWriter, r *http.Request) (string, *ws_manager.WorkspaceSettings, bool) {
 	logger := zerolog.Ctx(r.Context())
@@ -368,5 +374,37 @@ func (svc *FileService) GetFileMetadataService(w http.ResponseWriter, r *http.Re
 	WriteResponse(w, http.StatusOK, FileMetadataResponse{
 		Workspace: workspaceID,
 		Item:      item,
+	})
+}
+
+func (svc *FileService) GetUploadURLService(w http.ResponseWriter, r *http.Request) {
+	workspaceID, workspace, ok := svc.resolveAuthorizedWorkspace(w, r)
+	if !ok {
+		return
+	}
+
+	filename := r.URL.Query().Get("filename")
+	if filename == "" {
+		WriteResponse(w, http.StatusBadRequest, "filename query parameter is required")
+		return
+	}
+
+	objectStores, _ := collectStores(workspace)
+	objectStore, err := selectObjectStore(objectStores)
+	if err != nil {
+		WriteResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	uploadURL, err := svc.getObjectStoreUploadURL(r, objectStore, filename)
+	if err != nil {
+		WriteResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	WriteResponse(w, http.StatusOK, FileUploadURLResponse{
+		Workspace: workspaceID,
+		URL:       uploadURL,
+		FileName:  filename,
 	})
 }

--- a/api/services/files.go
+++ b/api/services/files.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	ws_manager "github.com/EO-DataHub/eodhp-workspace-manager/models"
@@ -23,6 +24,7 @@ const (
 	invalidStoreType  = "invalid store type"
 	defaultTimeFormat = "2006-01-02T15:04:05Z"
 	defaultFormMemory = int64(32 << 20) // 32MB
+	maxUploadBytes    = int64(6 << 30)  // 6GB
 )
 
 // STSClient defines the minimal interface needed for STS AssumeRoleWithWebIdentity.
@@ -383,9 +385,19 @@ func (svc *FileService) GetUploadURLService(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	filename := r.URL.Query().Get("filename")
+	filename := r.URL.Query().Get("file")
 	if filename == "" {
-		WriteResponse(w, http.StatusBadRequest, "filename query parameter is required")
+		WriteResponse(w, http.StatusBadRequest, "file query parameter is required")
+		return
+	}
+
+	size, err := strconv.ParseInt(r.URL.Query().Get("size"), 10, 64)
+	if err != nil || size <= 0 {
+		WriteResponse(w, http.StatusBadRequest, "size query parameter must be a positive integer")
+		return
+	}
+	if size > maxUploadBytes {
+		WriteResponse(w, http.StatusBadRequest, "file exceeds maximum upload size")
 		return
 	}
 
@@ -396,7 +408,7 @@ func (svc *FileService) GetUploadURLService(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	uploadURL, err := svc.getObjectStoreUploadURL(r, objectStore, filename)
+	uploadURL, err := svc.getObjectStoreUploadURL(r, objectStore, filename, size)
 	if err != nil {
 		WriteResponse(w, http.StatusInternalServerError, err.Error())
 		return

--- a/api/services/files_object.go
+++ b/api/services/files_object.go
@@ -6,6 +6,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strings"
+	"time"
 
 	ws_manager "github.com/EO-DataHub/eodhp-workspace-manager/models"
 	awsclient "github.com/EO-DataHub/eodhp-workspace-services/internal/aws"
@@ -167,6 +168,38 @@ func (svc *FileService) getObjectStoreMetadata(r *http.Request, store ws_manager
 		item.ETag = strings.Trim(*resp.ETag, "\"")
 	}
 	return item, nil
+}
+
+// getObjectStoreUploadURL generates a presigned S3 PutObject URL for a single file.
+// newS3Client is called before any data is read, so the JWT is still valid at credential exchange time.
+func (svc *FileService) getObjectStoreUploadURL(r *http.Request, store ws_manager.ObjectStore, filename string) (string, error) {
+	if store.Bucket == "" || store.Prefix == "" {
+		return "", fmt.Errorf("object store not provisioned")
+	}
+	if err := validateFileName(filename); err != nil {
+		return "", err
+	}
+
+	s3Client, err := svc.newS3Client(r)
+	if err != nil {
+		return "", err
+	}
+
+	key, err := safeS3Key(store.Prefix, filename)
+	if err != nil {
+		return "", err
+	}
+
+	presignClient := s3.NewPresignClient(s3Client)
+	req, err := presignClient.PresignPutObject(r.Context(), &s3.PutObjectInput{
+		Bucket: aws.String(store.Bucket),
+		Key:    aws.String(key),
+	}, s3.WithPresignExpires(time.Hour))
+	if err != nil {
+		return "", fmt.Errorf("failed to generate upload URL: %w", err)
+	}
+
+	return req.URL, nil
 }
 
 // newS3Client creates an S3 client using credentials resolved from the incoming request.

--- a/api/services/files_object.go
+++ b/api/services/files_object.go
@@ -172,7 +172,7 @@ func (svc *FileService) getObjectStoreMetadata(r *http.Request, store ws_manager
 
 // getObjectStoreUploadURL generates a presigned S3 PutObject URL for a single file.
 // newS3Client is called before any data is read, so the JWT is still valid at credential exchange time.
-func (svc *FileService) getObjectStoreUploadURL(r *http.Request, store ws_manager.ObjectStore, filename string) (string, error) {
+func (svc *FileService) getObjectStoreUploadURL(r *http.Request, store ws_manager.ObjectStore, filename string, size int64) (string, error) {
 	if store.Bucket == "" || store.Prefix == "" {
 		return "", fmt.Errorf("object store not provisioned")
 	}
@@ -192,8 +192,9 @@ func (svc *FileService) getObjectStoreUploadURL(r *http.Request, store ws_manage
 
 	presignClient := s3.NewPresignClient(s3Client)
 	req, err := presignClient.PresignPutObject(r.Context(), &s3.PutObjectInput{
-		Bucket: aws.String(store.Bucket),
-		Key:    aws.String(key),
+		Bucket:        aws.String(store.Bucket),
+		Key:           aws.String(key),
+		ContentLength: aws.Int64(size),
 	}, s3.WithPresignExpires(time.Hour))
 	if err != nil {
 		return "", fmt.Errorf("failed to generate upload URL: %w", err)

--- a/api/services/files_object_test.go
+++ b/api/services/files_object_test.go
@@ -173,6 +173,9 @@ func TestObjectStoreMethodsProvisioningValidation(t *testing.T) {
 
 	_, err = svc.getObjectStoreMetadata(req, ws_manager.ObjectStore{}, "a.tif")
 	require.EqualError(t, err, "object store not provisioned")
+
+	_, err = svc.getObjectStoreUploadURL(req, ws_manager.ObjectStore{}, "file.tif", 1024)
+	require.EqualError(t, err, "object store not provisioned")
 }
 
 func TestListObjectStoreItemsInvalidPrefixReturnsError(t *testing.T) {
@@ -233,6 +236,40 @@ func TestObjectStorePathValidationWithoutS3Call(t *testing.T) {
 		Prefix: "workspace/ws-1",
 	}, "bad/name.tif")
 	require.EqualError(t, err, "nested paths are not supported")
+
+	_, err = svc.getObjectStoreUploadURL(req, ws_manager.ObjectStore{
+		Bucket: "bucket-1",
+		Prefix: "workspace/ws-1",
+	}, "bad/name.tif", 1024)
+	require.EqualError(t, err, "nested paths are not supported")
+}
+
+func TestGetObjectStoreUploadURL(t *testing.T) {
+	svc := FileService{
+		Config: &appconfig.Config{
+			AWS: appconfig.AWSConfig{
+				Region: "us-east-1",
+				S3: appconfig.S3Config{
+					AccessKey: "local-key",
+					SecretKey: "local-secret",
+				},
+			},
+		},
+	}
+	store := ws_manager.ObjectStore{Bucket: "bucket-1", Prefix: "workspace/ws-1"}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	t.Run("success returns non-empty URL containing filename", func(t *testing.T) {
+		url, err := svc.getObjectStoreUploadURL(req, store, "file.tif", 1024)
+		require.NoError(t, err)
+		require.NotEmpty(t, url)
+		require.Contains(t, url, "file.tif")
+	})
+
+	t.Run("size at limit is accepted", func(t *testing.T) {
+		_, err := svc.getObjectStoreUploadURL(req, store, "file.tif", maxUploadBytes)
+		require.NoError(t, err)
+	})
 }
 
 type mockSTSClient struct {

--- a/api/services/files_test.go
+++ b/api/services/files_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -538,6 +539,51 @@ func newMultipartWorkspaceRequest(
 	req := newWorkspaceRequest(method, workspaceID, "", &body, claims)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	return req
+}
+
+func workspaceWithObjectStore(workspaceID string) *ws_manager.WorkspaceSettings {
+	stores := []ws_manager.Stores{
+		{
+			Object: []ws_manager.ObjectStore{
+				{Bucket: "bucket-1", Prefix: "workspace/" + workspaceID},
+			},
+		},
+	}
+	return &ws_manager.WorkspaceSettings{
+		Name:   workspaceID,
+		Stores: &stores,
+	}
+}
+
+func TestGetUploadURLServiceParameterValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"missing file param", "size=1024"},
+		{"missing size param", "file=foo.tif"},
+		{"size is zero", "file=foo.tif&size=0"},
+		{"size is negative", "file=foo.tif&size=-1"},
+		{"size exceeds limit", fmt.Sprintf("file=foo.tif&size=%d", maxUploadBytes+1)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDB := new(MockWorkspaceDB)
+			claims := hubAdminClaims()
+			workspaceID := "ws-1"
+			mockDB.On("GetWorkspace", workspaceID).Return(workspaceWithObjectStore(workspaceID), nil).Once()
+
+			svc := FileService{DB: mockDB}
+			req := newWorkspaceRequest(http.MethodGet, workspaceID, tc.query, nil, &claims)
+			w := httptest.NewRecorder()
+
+			svc.GetUploadURLService(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+			mockDB.AssertExpectations(t)
+		})
+	}
 }
 
 func workspaceWithBlockStore(workspaceID string) *ws_manager.WorkspaceSettings {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -133,6 +133,7 @@ var serveCmd = &cobra.Command{
 		api.HandleFunc("/workspaces/{workspace-id}/files/block", handlers.UploadWorkspaceBlockFiles(fileService)).Methods(http.MethodPost)
 		api.HandleFunc("/workspaces/{workspace-id}/files/object", handlers.DeleteWorkspaceObjectFile(fileService)).Methods(http.MethodDelete)
 		api.HandleFunc("/workspaces/{workspace-id}/files/block", handlers.DeleteWorkspaceBlockFile(fileService)).Methods(http.MethodDelete)
+		api.HandleFunc("/workspaces/{workspace-id}/files/object/upload-url", handlers.GetWorkspaceObjectFileUploadURL(fileService)).Methods(http.MethodGet)
 		api.HandleFunc("/workspaces/{workspace-id}/files/object/metadata", handlers.GetWorkspaceObjectFileMetadata(fileService)).Methods(http.MethodGet)
 		api.HandleFunc("/workspaces/{workspace-id}/files/block/metadata", handlers.GetWorkspaceBlockFileMetadata(fileService)).Methods(http.MethodGet)
 


### PR DESCRIPTION
## Summary

- Adds `GET /workspaces/{workspace-id}/files/object/upload-url?filename=<name>` which returns a presigned S3 `PutObject` URL valid for 1 hour
- The client uploads the file body directly to S3 (HTTP `PUT`), bypassing this service and nginx entirely for the data transfer — no JWT needs to remain valid during the upload
- Fixes the root cause of object store uploads failing for files that take longer than the JWT lifespan (~9.5 min) to transfer

## Background

PR #41 (`fix/s3-credentials-before-multipart-read`) moved `AssumeRoleWithWebIdentity` before `ParseMultipartForm` so STS credentials are acquired while the JWT is still valid. That covers uploads up to ~1 hour. This PR extends coverage to arbitrarily large files by generating a presigned URL at request time and letting S3 handle the transfer directly.

## Client integration

Two-step flow:

1. `GET /workspaces/{id}/files/object/upload-url?filename=foo.tif` with `Authorization: Bearer <token>` — returns `{ workspace, url, fileName }`
2. `PUT <url>` with the file body and `Content-Type` header — **no** `Authorization` header (credentials are embedded in the URL)

See the platform-bugs issue for full JS examples.

## Test plan

- [ ] Request the endpoint with a valid JWT and confirm a presigned URL is returned
- [ ] PUT a file directly to the returned URL and confirm it appears in the object store