### PR TITLE
fix: skip empty RootDirectory to avoid wiping block store mount_point

### DIFF
--- a/db/workspaces.go
+++ b/db/workspaces.go
@@ -437,6 +437,13 @@ func (w *WorkspaceDB) UpdateWorkspaceStatus(status ws_manager.WorkspaceStatus) e
 
 	// Update block_store table
 	for _, efs := range status.AWS.EFS.AccessPoints {
+		// RootDirectory is omitempty and can be blank in partial reconcile statuses.
+		// Skip these so we never overwrite an already-provisioned mount_point with an
+		// empty value, which would make the block store appear "not provisioned".
+		if strings.TrimSpace(efs.RootDirectory) == "" {
+			continue
+		}
+
 		err = w.execQuery(tx, `
 			UPDATE block_stores
 			SET access_point_id = $1, mount_point = $2

--- a/db/workspaces.go
+++ b/db/workspaces.go
@@ -8,6 +8,7 @@ import (
 	ws_manager "github.com/EO-DataHub/eodhp-workspace-manager/models"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/rs/zerolog/log"
 )
 
 // getWorkspace retrieves a workspace by name.
@@ -441,6 +442,11 @@ func (w *WorkspaceDB) UpdateWorkspaceStatus(status ws_manager.WorkspaceStatus) e
 		// Skip these so we never overwrite an already-provisioned mount_point with an
 		// empty value, which would make the block store appear "not provisioned".
 		if strings.TrimSpace(efs.RootDirectory) == "" {
+			log.Warn().
+				Str("workspace_name", status.Name).
+				Str("access_point_name", efs.Name).
+				Str("access_point_id", efs.AccessPointID).
+				Msg("Skipping block store update: status has empty RootDirectory; preserving existing mount_point")
 			continue
 		}
 


### PR DESCRIPTION
In **UpdateWorkspaceStatus** (workspace-services db/workspaces.go) we added a guard that skips any EFS access point whose RootDirectory is blank, so an incomplete status message can no longer overwrite an already-provisioned mount_point with "".

