### PR TITLE
feat: add Open Cosmos workspace session secret endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Run this with:
 
 ### Docker Development Environment
 This repository includes a local Docker Compose setup that runs:
+- K3s (local Kubernetes cluster)
 - Postgres
 - Pulsar (standalone)
 - MinIO (S3-compatible)
@@ -123,8 +124,8 @@ Default local endpoints:
 - MinIO Console: http://localhost:9001 (user: `minio`, pass: `minio123`)
 
 Expected container state:
-- Running: `eodhp-workspace-services`, `eodhp-postgres`, `eodhp-pulsar`, `eodhp-minio`, `eodhp-keycloak`
-- Exited (one-off jobs): `workspace-migrate-1`, `db-seed-1`, `minio-init-1`, `pulsar-init-1`
+- Running: `eodhp-workspace-services`, `eodhp-k3s`, `eodhp-postgres`, `eodhp-pulsar`, `eodhp-minio`, `eodhp-keycloak`
+- Exited (one-off jobs): `workspace-migrate-1`, `db-seed-1`, `k3s-init-1`, `minio-init-1`, `pulsar-init-1`
 
 Keycloak dev user:
 - username: `dev-user`
@@ -140,6 +141,37 @@ curl -X POST http://localhost:8081/realms/eodhp/protocol/openid-connect/token \
 ```
 
 MinIO bucket (created automatically): `workspaces-eodhp-local`
+
+### Local Kubernetes secrets
+
+The Compose environment starts a local K3s cluster and mounts its internal kubeconfig into Workspace Services. This enables the linked-account and Open Cosmos session routes without requiring a developer's host kubeconfig.
+
+The `k3s-init` service creates namespaces for the workspaces in `config/db/seed.sql`:
+
+```text
+ws-eodh-demos
+ws-samples-airbus-optical
+ws-samples-airbus-sar
+ws-samples-planet
+```
+
+List the secrets for a local workspace:
+
+```bash
+docker compose exec k3s kubectl -n ws-eodh-demos get secrets
+```
+
+Inspect an Open Cosmos user secret:
+
+```bash
+docker compose exec k3s kubectl -n ws-eodh-demos get secret oauth-opencosmos-<user-sub> -o yaml
+```
+
+The values under `data` are Base64 encoded by Kubernetes. Decode an individual value with:
+
+```bash
+docker compose exec k3s kubectl -n ws-eodh-demos get secret oauth-opencosmos-<user-sub> -o jsonpath='{.data.user_sub}' | base64 -d
+```
 
 ### Database
 To connect to the database, setup an SSH tunnel:

--- a/api/handlers/linked-accounts.go
+++ b/api/handlers/linked-accounts.go
@@ -20,6 +20,20 @@ func CreateLinkedAccount(svc *services.LinkedAccountService) http.HandlerFunc {
 	}
 }
 
+// CreateOpenCosmosSession handles HTTP requests for persisting an Open Cosmos session for a workspace.
+func CreateOpenCosmosSession(svc *services.LinkedAccountService) http.HandlerFunc {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		// Get a token from keycloak so we can interact with its API
+		if !ensureKeycloakToken(w, svc.KC) {
+			return
+		}
+
+		svc.CreateOpenCosmosSessionService(w, r)
+	}
+}
+
 // GetAccounts handles HTTP requests for retrieving accounts.
 func GetLinkedAccounts(svc *services.LinkedAccountService) http.HandlerFunc {
 

--- a/api/handlers/linked-accounts.go
+++ b/api/handlers/linked-accounts.go
@@ -21,6 +21,20 @@ func CreateLinkedAccount(svc *services.LinkedAccountService) http.HandlerFunc {
 }
 
 // CreateOpenCosmosSession handles HTTP requests for persisting an Open Cosmos session for a workspace.
+// @Summary Store an Open Cosmos OAuth session
+// @Description Creates or updates the authenticated user's Open Cosmos OAuth session in the workspace Kubernetes namespace.
+// @Tags Linked Accounts
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param workspace-id path string true "Workspace ID"
+// @Param session body services.OpenCosmosSessionPayload true "Open Cosmos OAuth session"
+// @Success 201
+// @Failure 400 {object} string
+// @Failure 401 {object} string
+// @Failure 403 {object} string
+// @Failure 500 {object} string
+// @Router /workspaces/{workspace-id}/open-cosmos/session [post]
 func CreateOpenCosmosSession(svc *services.LinkedAccountService) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/api/services/linked-accounts.go
+++ b/api/services/linked-accounts.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/EO-DataHub/eodhp-workspace-services/api/middleware"
@@ -51,7 +52,7 @@ type LinkedAccountService struct {
 	Config         *appconfig.Config
 	DB             *db.WorkspaceDB
 	SecretsManager *secretsmanager.Client
-	K8sClient      *kubernetes.Clientset
+	K8sClient      kubernetes.Interface
 	KC             KeycloakClientInterface
 }
 
@@ -62,10 +63,77 @@ type Payload struct {
 	Contracts AirbusContractsData `json:"contracts,omitempty"` // Airbus only
 }
 
+type OpenCosmosUser struct {
+	Sub   string `json:"sub,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
+type OpenCosmosSessionPayload struct {
+	AccessToken  string          `json:"accessToken"`
+	RefreshToken string          `json:"refreshToken,omitempty"`
+	ExpiresAt    int64           `json:"expiresAt"`
+	Scope        string          `json:"scope,omitempty"`
+	TokenType    string          `json:"tokenType,omitempty"`
+	User         *OpenCosmosUser `json:"user,omitempty"`
+}
+
+func sanitizeOpenCosmosUserSub(userSub string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(userSub))
+
+	// Replace characters that are common in identity subjects but invalid or awkward in
+	// Kubernetes secret names. We collapse them all to "-" so consumers can apply the
+	// same deterministic transformation when reconstructing the secret name.
+	replacer := strings.NewReplacer(
+		":", "-",
+		"/", "-",
+		"\\", "-",
+		"_", "-",
+		".", "-",
+		"@", "-",
+		" ", "-",
+	)
+	normalized = replacer.Replace(normalized)
+
+	// Keep only lowercase letters, digits and hyphens because Kubernetes resource
+	// names must be DNS-label friendly. Any other character becomes "-".
+	var builder strings.Builder
+	builder.Grow(len(normalized))
+	for _, r := range normalized {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			builder.WriteRune(r)
+			continue
+		}
+		builder.WriteByte('-')
+	}
+
+	sanitized := builder.String()
+
+	// Collapse repeated hyphens so equivalent subjects do not produce visually noisy
+	// names like "auth0---user". This also makes reproduction easier for consumers.
+	for strings.Contains(sanitized, "--") {
+		sanitized = strings.ReplaceAll(sanitized, "--", "-")
+	}
+
+	// Trim leading and trailing hyphens because Kubernetes names cannot start or end
+	// with a separator.
+	sanitized = strings.Trim(sanitized, "-")
+
+	// Refuse to store the session if the subject sanitizes down to nothing. That would
+	// create an ambiguous secret name and make it impossible to attribute the secret to
+	// a concrete user later.
+	if sanitized == "" {
+		return "", fmt.Errorf("user sub %q is invalid after sanitization", userSub)
+	}
+
+	return sanitized, nil
+}
+
 type LinkedAccountServiceInterface interface {
 	GetLinkedAccounts(w http.ResponseWriter, r *http.Request)
 	DeleteLinkedAccountService(w http.ResponseWriter, r *http.Request)
 	CreateLinkedAccountService(w http.ResponseWriter, r *http.Request)
+	CreateOpenCosmosSessionService(w http.ResponseWriter, r *http.Request)
 	storeOTPSecret(otpKey, secretName, namespace string) error
 	storeCiphertextInAWSSecrets(ciphertext, secretName, payloadName string) error
 	getSecretKeysFromAWS(secretName string) ([]string, error)
@@ -269,6 +337,85 @@ func (svc *LinkedAccountService) CreateLinkedAccountService(w http.ResponseWrite
 	}
 	WriteResponse(w, http.StatusCreated, nil)
 
+}
+
+// CreateOpenCosmosSessionService stores an Open Cosmos OAuth session in a workspace-scoped Kubernetes secret.
+func (svc *LinkedAccountService) CreateOpenCosmosSessionService(w http.ResponseWriter, r *http.Request) {
+
+	logger := zerolog.Ctx(r.Context())
+
+	claims, ok := r.Context().Value(middleware.ClaimsKey).(authn.Claims)
+	if !ok {
+		logger.Warn().Msg("Unauthorized request: missing claims")
+		WriteResponse(w, http.StatusUnauthorized, nil)
+		return
+	}
+
+	workspaceID := mux.Vars(r)["workspace-id"]
+	namespace := "ws-" + workspaceID
+
+	authorized, err := isUserWorkspaceAuthorized(svc.DB, svc.KC, claims, workspaceID, true)
+	if err != nil {
+		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to authorize workspace")
+		WriteResponse(w, http.StatusInternalServerError, nil)
+		return
+	}
+
+	if !authorized {
+		WriteResponse(w, http.StatusForbidden, "Access Denied: Must be account owner of the workspace")
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to read request body")
+		WriteResponse(w, http.StatusBadRequest, "Failed to read request body")
+		return
+	}
+	defer r.Body.Close()
+
+	var payload OpenCosmosSessionPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Invalid JSON payload")
+		WriteResponse(w, http.StatusBadRequest, "Invalid JSON payload")
+		return
+	}
+
+	if payload.AccessToken == "" {
+		WriteResponse(w, http.StatusBadRequest, "Field 'accessToken' is required and cannot be empty")
+		return
+	}
+
+	if payload.RefreshToken == "" {
+		WriteResponse(w, http.StatusBadRequest, "Field 'refreshToken' is required and cannot be empty")
+		return
+	}
+
+	if payload.ExpiresAt <= 0 {
+		WriteResponse(w, http.StatusBadRequest, "Field 'expiresAt' is required and must be a positive timestamp")
+		return
+	}
+
+	if payload.User == nil || payload.User.Sub == "" {
+		WriteResponse(w, http.StatusBadRequest, "Field 'user.sub' is required and cannot be empty")
+		return
+	}
+
+	sanitizedUserSub, err := sanitizeOpenCosmosUserSub(payload.User.Sub)
+	if err != nil {
+		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Invalid Open Cosmos user subject for secret naming")
+		WriteResponse(w, http.StatusBadRequest, "Field 'user.sub' is invalid for secret naming")
+		return
+	}
+
+	k8sSecretName := "oauth-opencosmos-" + sanitizedUserSub
+	if err := svc.storeOpenCosmosSessionSecret(payload, k8sSecretName, namespace); err != nil {
+		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to store Open Cosmos session in Kubernetes")
+		WriteResponse(w, http.StatusInternalServerError, fmt.Sprintf("Failed to store Open Cosmos session in Kubernetes: %v", err))
+		return
+	}
+
+	WriteResponse(w, http.StatusCreated, nil)
 }
 
 // ValidateAirbusLinkedAccountService validates the Airbus key and returns the associated contracts.
@@ -519,6 +666,49 @@ func (svc *LinkedAccountService) storeK8sSecrets(otpKey, secretName, namespace s
 			return fmt.Errorf("failed to create Kubernetes secret: %v", err)
 		}
 	}
+	return nil
+}
+
+func (svc *LinkedAccountService) storeOpenCosmosSessionSecret(session OpenCosmosSessionPayload, secretName, namespace string) error {
+	secretsData := map[string][]byte{
+		"access_token":  []byte(session.AccessToken),
+		"refresh_token": []byte(session.RefreshToken),
+		"expires_at":    []byte(strconv.FormatInt(session.ExpiresAt, 10)),
+	}
+
+	if session.Scope != "" {
+		secretsData["scope"] = []byte(session.Scope)
+	}
+
+	if session.TokenType != "" {
+		secretsData["token_type"] = []byte(session.TokenType)
+	}
+
+	if session.User != nil {
+		if session.User.Sub != "" {
+			secretsData["user_sub"] = []byte(session.User.Sub)
+		}
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		Data: secretsData,
+	}
+
+	_, err := svc.K8sClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	if err != nil {
+		if k8sErrors.IsAlreadyExists(err) {
+			_, err = svc.K8sClient.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to update existing Kubernetes secret: %v", err)
+			}
+		} else {
+			return fmt.Errorf("failed to create Kubernetes secret: %v", err)
+		}
+	}
+
 	return nil
 }
 

--- a/api/services/linked-accounts_test.go
+++ b/api/services/linked-accounts_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type MockLinkedAccountService struct {
@@ -33,6 +36,10 @@ func (m *MockLinkedAccountService) DeleteLinkedAccountService(w http.ResponseWri
 func (m *MockLinkedAccountService) CreateLinkedAccountService(w http.ResponseWriter, r *http.Request) {
 	m.Called(w, r)
 	//w.WriteHeader(http.StatusCreated) // Ensure the mock sets the correct status code
+}
+
+func (m *MockLinkedAccountService) CreateOpenCosmosSessionService(w http.ResponseWriter, r *http.Request) {
+	m.Called(w, r)
 }
 
 func (m *MockLinkedAccountService) storeOTPSecret(otpKey, secretName, namespace string) error {
@@ -131,6 +138,53 @@ func TestDeleteSecretKeyFromAWS(t *testing.T) {
 	mockService.AssertExpectations(t)
 }
 
+func TestStoreOpenCosmosSessionSecret(t *testing.T) {
+	t.Parallel()
+
+	namespace := "ws-test-workspace"
+	secretName := "oauth-opencosmos-auth0-user-sub-example-com"
+	svc := &LinkedAccountService{
+		K8sClient: fake.NewSimpleClientset(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}),
+	}
+
+	payload := OpenCosmosSessionPayload{
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		ExpiresAt:    1780862369915,
+		Scope:        "openid profile email data offline_access",
+		TokenType:    "Bearer",
+		User: &OpenCosmosUser{
+			Sub:   "auth0|User_Sub@example.com",
+			Name:  "David Tamayo",
+			Email: "dtamayo@sparkeo.com",
+		},
+	}
+
+	sanitizedUserSub, err := sanitizeOpenCosmosUserSub(payload.User.Sub)
+	require.NoError(t, err)
+	require.Equal(t, secretName, "oauth-opencosmos-"+sanitizedUserSub)
+
+	err = svc.storeOpenCosmosSessionSecret(payload, secretName, namespace)
+	require.NoError(t, err)
+
+	secret, err := svc.K8sClient.CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, payload.AccessToken, string(secret.Data["access_token"]))
+	require.Equal(t, payload.RefreshToken, string(secret.Data["refresh_token"]))
+	require.Equal(t, "1780862369915", string(secret.Data["expires_at"]))
+	require.Equal(t, payload.Scope, string(secret.Data["scope"]))
+	require.Equal(t, payload.TokenType, string(secret.Data["token_type"]))
+	require.Equal(t, payload.User.Sub, string(secret.Data["user_sub"]))
+	_, hasUserEmail := secret.Data["user_email"]
+	require.False(t, hasUserEmail)
+	_, hasUserName := secret.Data["user_name"]
+	require.False(t, hasUserName)
+	_, hasSession := secret.Data["session"]
+	require.False(t, hasSession)
+}
+
 func TestValidateAirbusLinkedAccountService_OpticalOrSAR(t *testing.T) {
 	t.Parallel()
 
@@ -149,10 +203,10 @@ func TestValidateAirbusLinkedAccountService_OpticalOrSAR(t *testing.T) {
 		skipBodyAsserts bool
 	}{
 		{
-			name:           "both_upstream_fail",
-			opticalStatus:  http.StatusInternalServerError,
-			sarStatus:      http.StatusForbidden,
-			wantHTTPStatus: http.StatusInternalServerError,
+			name:            "both_upstream_fail",
+			opticalStatus:   http.StatusInternalServerError,
+			sarStatus:       http.StatusForbidden,
+			wantHTTPStatus:  http.StatusInternalServerError,
 			skipBodyAsserts: true,
 		},
 		{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -151,6 +151,7 @@ var serveCmd = &cobra.Command{
 			api.HandleFunc("/workspaces/{workspace-id}/linked-accounts/{provider}", handlers.DeleteLinkedAccount(linkedAccountService)).Methods(http.MethodDelete)
 			api.HandleFunc("/workspaces/{workspace-id}/linked-accounts/airbus/validate", handlers.ValidateAirbusLinkedAccount(linkedAccountService)).Methods(http.MethodPost)
 			api.HandleFunc("/workspaces/{workspace-id}/linked-accounts/planet/validate", handlers.ValidatePlanetLinkedAccount(linkedAccountService)).Methods(http.MethodPost)
+			api.HandleFunc("/workspaces/{workspace-id}/open-cosmos/session", handlers.CreateOpenCosmosSession(linkedAccountService)).Methods(http.MethodPost)
 		} else {
 			log.Warn().Msg("Skipping linked-accounts routes (Kubernetes client unavailable)")
 		}
@@ -177,7 +178,7 @@ func init() {
 
 }
 
-func initializeK8sClient() (*kubernetes.Clientset, error) {
+func initializeK8sClient() (kubernetes.Interface, error) {
 	var config *rest.Config
 	var err error
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,54 @@
 version: "3.9"
 
 services:
+  k3s:
+    image: rancher/k3s:v1.32.1-k3s1
+    container_name: eodhp-k3s
+    command:
+      - server
+      - --disable-agent
+      - --disable=traefik
+      - --disable=servicelb
+      - --disable=metrics-server
+      - --tls-san=k3s
+    volumes:
+      - k3s_data:/var/lib/rancher/k3s
+      - k3s_server_config:/etc/rancher/k3s
+
+  k3s-init:
+    image: rancher/k3s:v1.32.1-k3s1
+    depends_on:
+      - k3s
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        until [ -f /source/k3s.yaml ]; do
+          echo "waiting for the local Kubernetes kubeconfig..."
+          sleep 2
+        done
+
+        cp /source/k3s.yaml /output/config
+        sed -i 's/127.0.0.1/k3s/' /output/config
+        chmod 0644 /output/config
+
+        until kubectl --kubeconfig /output/config get --raw=/readyz >/dev/null 2>&1; do
+          echo "waiting for the local Kubernetes API..."
+          sleep 2
+        done
+
+        for namespace in \
+          ws-eodh-demos \
+          ws-samples-airbus-optical \
+          ws-samples-airbus-sar \
+          ws-samples-planet; do
+          kubectl --kubeconfig /output/config create namespace "$${namespace}" \
+            --dry-run=client -o yaml | \
+            kubectl --kubeconfig /output/config apply -f -
+        done
+    volumes:
+      - k3s_server_config:/source:ro
+      - k3s_client_config:/output
+
   postgres:
     image: postgres:15
     container_name: eodhp-postgres
@@ -165,6 +213,8 @@ services:
         condition: service_completed_successfully
       db-seed:
         condition: service_completed_successfully
+      k3s-init:
+        condition: service_completed_successfully
     environment:
       ENV: local
       SQL_USER: eodhp
@@ -184,8 +234,12 @@ services:
     command: ["serve", "--host=0.0.0.0", "--port=8080", "--config", "/config/local-docker.yaml"]
     volumes:
       - ./config/local-docker.yaml:/config/local-docker.yaml
+      - k3s_client_config:/root/.kube:ro
 
 volumes:
   pgdata:
   minio_data:
   block_data:
+  k3s_data:
+  k3s_server_config:
+  k3s_client_config:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -722,6 +722,151 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{workspace-id}/files/object/upload-url": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a presigned S3 PutObject URL. The client uploads the file directly to S3 using the returned URL, bypassing this service entirely for the data transfer.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workspace Files Management"
+                ],
+                "summary": "Get a presigned upload URL for the workspace object store",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "workspace-id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path within the workspace",
+                        "name": "file",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "File size in bytes",
+                        "name": "size",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/services.FileUploadURLResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace-id}/open-cosmos/session": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates or updates the authenticated user's Open Cosmos OAuth session in the workspace Kubernetes namespace.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Linked Accounts"
+                ],
+                "summary": "Store an Open Cosmos OAuth session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "workspace-id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Open Cosmos OAuth session",
+                        "name": "session",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/services.OpenCosmosSessionPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{workspace-id}/users": {
             "get": {
                 "description": "Retrieve a list of users who are members of the specified workspace.",
@@ -995,7 +1140,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.S3Credentials"
+                            "$ref": "#/definitions/awsclient.S3Credentials"
                         }
                     },
                     "400": {
@@ -1086,6 +1231,23 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "awsclient.S3Credentials": {
+            "type": "object",
+            "properties": {
+                "accessKeyId": {
+                    "type": "string"
+                },
+                "expiration": {
+                    "type": "string"
+                },
+                "secretAccessKey": {
+                    "type": "string"
+                },
+                "sessionToken": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.AuthSessionResponse": {
             "type": "object",
             "properties": {
@@ -1102,23 +1264,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "type": "string"
-                }
-            }
-        },
-        "handlers.S3Credentials": {
-            "type": "object",
-            "properties": {
-                "accessKeyId": {
-                    "type": "string"
-                },
-                "expiration": {
-                    "type": "string"
-                },
-                "secretAccessKey": {
-                    "type": "string"
-                },
-                "sessionToken": {
                     "type": "string"
                 }
             }
@@ -1356,6 +1501,57 @@ const docTemplate = `{
                     }
                 },
                 "workspace": {
+                    "type": "string"
+                }
+            }
+        },
+        "services.FileUploadURLResponse": {
+            "type": "object",
+            "properties": {
+                "fileName": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "workspace": {
+                    "type": "string"
+                }
+            }
+        },
+        "services.OpenCosmosSessionPayload": {
+            "type": "object",
+            "properties": {
+                "accessToken": {
+                    "type": "string"
+                },
+                "expiresAt": {
+                    "type": "integer"
+                },
+                "refreshToken": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "tokenType": {
+                    "type": "string"
+                },
+                "user": {
+                    "$ref": "#/definitions/services.OpenCosmosUser"
+                }
+            }
+        },
+        "services.OpenCosmosUser": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sub": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -714,6 +714,151 @@
                 }
             }
         },
+        "/workspaces/{workspace-id}/files/object/upload-url": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a presigned S3 PutObject URL. The client uploads the file directly to S3 using the returned URL, bypassing this service entirely for the data transfer.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workspace Files Management"
+                ],
+                "summary": "Get a presigned upload URL for the workspace object store",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "workspace-id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path within the workspace",
+                        "name": "file",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "File size in bytes",
+                        "name": "size",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/services.FileUploadURLResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace-id}/open-cosmos/session": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates or updates the authenticated user's Open Cosmos OAuth session in the workspace Kubernetes namespace.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Linked Accounts"
+                ],
+                "summary": "Store an Open Cosmos OAuth session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "workspace-id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Open Cosmos OAuth session",
+                        "name": "session",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/services.OpenCosmosSessionPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{workspace-id}/users": {
             "get": {
                 "description": "Retrieve a list of users who are members of the specified workspace.",
@@ -987,7 +1132,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.S3Credentials"
+                            "$ref": "#/definitions/awsclient.S3Credentials"
                         }
                     },
                     "400": {
@@ -1078,6 +1223,23 @@
         }
     },
     "definitions": {
+        "awsclient.S3Credentials": {
+            "type": "object",
+            "properties": {
+                "accessKeyId": {
+                    "type": "string"
+                },
+                "expiration": {
+                    "type": "string"
+                },
+                "secretAccessKey": {
+                    "type": "string"
+                },
+                "sessionToken": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.AuthSessionResponse": {
             "type": "object",
             "properties": {
@@ -1094,23 +1256,6 @@
                     "type": "string"
                 },
                 "scope": {
-                    "type": "string"
-                }
-            }
-        },
-        "handlers.S3Credentials": {
-            "type": "object",
-            "properties": {
-                "accessKeyId": {
-                    "type": "string"
-                },
-                "expiration": {
-                    "type": "string"
-                },
-                "secretAccessKey": {
-                    "type": "string"
-                },
-                "sessionToken": {
                     "type": "string"
                 }
             }
@@ -1348,6 +1493,57 @@
                     }
                 },
                 "workspace": {
+                    "type": "string"
+                }
+            }
+        },
+        "services.FileUploadURLResponse": {
+            "type": "object",
+            "properties": {
+                "fileName": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "workspace": {
+                    "type": "string"
+                }
+            }
+        },
+        "services.OpenCosmosSessionPayload": {
+            "type": "object",
+            "properties": {
+                "accessToken": {
+                    "type": "string"
+                },
+                "expiresAt": {
+                    "type": "integer"
+                },
+                "refreshToken": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "tokenType": {
+                    "type": "string"
+                },
+                "user": {
+                    "$ref": "#/definitions/services.OpenCosmosUser"
+                }
+            }
+        },
+        "services.OpenCosmosUser": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sub": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,15 @@
 definitions:
+  awsclient.S3Credentials:
+    properties:
+      accessKeyId:
+        type: string
+      expiration:
+        type: string
+      secretAccessKey:
+        type: string
+      sessionToken:
+        type: string
+    type: object
   handlers.AuthSessionResponse:
     properties:
       access:
@@ -10,17 +21,6 @@ definitions:
       refreshExpiry:
         type: string
       scope:
-        type: string
-    type: object
-  handlers.S3Credentials:
-    properties:
-      accessKeyId:
-        type: string
-      expiration:
-        type: string
-      secretAccessKey:
-        type: string
-      sessionToken:
         type: string
     type: object
   models.Account:
@@ -177,6 +177,39 @@ definitions:
       workspace:
         type: string
     type: object
+  services.FileUploadURLResponse:
+    properties:
+      fileName:
+        type: string
+      url:
+        type: string
+      workspace:
+        type: string
+    type: object
+  services.OpenCosmosSessionPayload:
+    properties:
+      accessToken:
+        type: string
+      expiresAt:
+        type: integer
+      refreshToken:
+        type: string
+      scope:
+        type: string
+      tokenType:
+        type: string
+      user:
+        $ref: '#/definitions/services.OpenCosmosUser'
+    type: object
+  services.OpenCosmosUser:
+    properties:
+      email:
+        type: string
+      name:
+        type: string
+      sub:
+        type: string
+    type: object
 info:
   contact: {}
   description: This is the API for the EODHP Workspace Services.
@@ -330,7 +363,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.S3Credentials'
+            $ref: '#/definitions/awsclient.S3Credentials'
         "400":
           description: Bad Request
           schema:
@@ -733,6 +766,103 @@ paths:
       summary: Get object store file metadata
       tags:
       - Workspace Files Management
+  /workspaces/{workspace-id}/files/object/upload-url:
+    get:
+      description: Returns a presigned S3 PutObject URL. The client uploads the file
+        directly to S3 using the returned URL, bypassing this service entirely for
+        the data transfer.
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: workspace-id
+        required: true
+        type: string
+      - description: File path within the workspace
+        in: query
+        name: file
+        required: true
+        type: string
+      - description: File size in bytes
+        in: query
+        name: size
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/services.FileUploadURLResponse'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get a presigned upload URL for the workspace object store
+      tags:
+      - Workspace Files Management
+  /workspaces/{workspace-id}/open-cosmos/session:
+    post:
+      consumes:
+      - application/json
+      description: Creates or updates the authenticated user's Open Cosmos OAuth session
+        in the workspace Kubernetes namespace.
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: workspace-id
+        required: true
+        type: string
+      - description: Open Cosmos OAuth session
+        in: body
+        name: session
+        required: true
+        schema:
+          $ref: '#/definitions/services.OpenCosmosSessionPayload'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Store an Open Cosmos OAuth session
+      tags:
+      - Linked Accounts
   /workspaces/{workspace-id}/users:
     get:
       consumes:


### PR DESCRIPTION
This PR adds backend support for storing Open Cosmos OAuth sessions in workspace Kubernetes secrets.

**Changes**
- Added POST /workspaces/{workspace-id}/open-cosmos/session
- Stores Open Cosmos session data in the workspace namespace
- Uses one secret per user: `oauth-opencosmos-{user-sub}`
- Fails the request if user.sub cannot be sanitized into a valid secret name


**New changes in "Add local K3s support for Kubernetes secret testing" commit:**
Added a Docker-based local K3s environment so developers can test Kubernetes-backed features without configuring an external cluster or personal kubeconfig. The setup automatically initializes workspace namespaces and mounts the generated kubeconfig into Workspace Services, enabling local end-to-end testing of Kubernetes Secret persistence.


**Note:** Swagger documentation was regenerated to include the new Open Cosmos endpoint. This also synchronized previously undocumented S3 pre-signed upload URL endpoint.


<img width="1513" height="597" alt="image" src="https://github.com/user-attachments/assets/31cd854f-9df2-4be3-ac7d-d3d4bcb15b3f" />

<img width="1498" height="787" alt="image" src="https://github.com/user-attachments/assets/0aee03da-765e-474e-815d-a142fbecb734" />


<img width="1458" height="745" alt="image" src="https://github.com/user-attachments/assets/913bb6cc-835a-4c7d-ac66-857f37f8eab2" />

