### PR TITLE
feat: add organization id to open cosmos session endpoint

### DIFF
--- a/api/services/linked-accounts.go
+++ b/api/services/linked-accounts.go
@@ -64,11 +64,12 @@ type Payload struct {
 }
 
 type OpenCosmosSessionPayload struct {
-	AccessToken  string `json:"accessToken"`
-	RefreshToken string `json:"refreshToken,omitempty"`
-	ExpiresAt    int64  `json:"expiresAt"`
-	Scope        string `json:"scope,omitempty"`
-	TokenType    string `json:"tokenType,omitempty"`
+	AccessToken    string `json:"accessToken"`
+	RefreshToken   string `json:"refreshToken,omitempty"`
+	ExpiresAt      int64  `json:"expiresAt"`
+	Scope          string `json:"scope,omitempty"`
+	TokenType      string `json:"tokenType,omitempty"`
+	OrganizationID *int64 `json:"organization_id"`
 }
 
 const openCosmosSecretName = "oauth-opencosmos"
@@ -340,6 +341,11 @@ func (svc *LinkedAccountService) CreateOpenCosmosSessionService(w http.ResponseW
 		return
 	}
 
+	if payload.OrganizationID == nil || *payload.OrganizationID < 0 {
+		WriteResponse(w, http.StatusBadRequest, "Field 'organization_id' is required and must be a non-negative number")
+		return
+	}
+
 	if err := svc.storeOpenCosmosSessionSecret(payload, openCosmosSecretName, namespace); err != nil {
 		logger.Error().Err(err).Str("workspace_id", workspaceID).Msg("Failed to store Open Cosmos session in Kubernetes")
 		WriteResponse(w, http.StatusInternalServerError, fmt.Sprintf("Failed to store Open Cosmos session in Kubernetes: %v", err))
@@ -602,9 +608,10 @@ func (svc *LinkedAccountService) storeK8sSecrets(otpKey, secretName, namespace s
 
 func (svc *LinkedAccountService) storeOpenCosmosSessionSecret(session OpenCosmosSessionPayload, secretName, namespace string) error {
 	secretsData := map[string][]byte{
-		"access_token":  []byte(session.AccessToken),
-		"refresh_token": []byte(session.RefreshToken),
-		"expires_at":    []byte(strconv.FormatInt(session.ExpiresAt, 10)),
+		"access_token":    []byte(session.AccessToken),
+		"refresh_token":   []byte(session.RefreshToken),
+		"expires_at":      []byte(strconv.FormatInt(session.ExpiresAt, 10)),
+		"organization_id": []byte(strconv.FormatInt(*session.OrganizationID, 10)),
 	}
 
 	if session.Scope != "" {

--- a/api/services/linked-accounts_test.go
+++ b/api/services/linked-accounts_test.go
@@ -141,6 +141,8 @@ func TestDeleteSecretKeyFromAWS(t *testing.T) {
 func TestStoreOpenCosmosSessionSecret(t *testing.T) {
 	t.Parallel()
 
+	organizationID := int64(0)
+	replacementOrganizationID := int64(166)
 	namespace := "ws-test-workspace"
 	secretName := openCosmosSecretName
 	svc := &LinkedAccountService{
@@ -150,11 +152,12 @@ func TestStoreOpenCosmosSessionSecret(t *testing.T) {
 	}
 
 	payload := OpenCosmosSessionPayload{
-		AccessToken:  "access-token",
-		RefreshToken: "refresh-token",
-		ExpiresAt:    1780862369915,
-		Scope:        "openid profile email data offline_access",
-		TokenType:    "Bearer",
+		AccessToken:    "access-token",
+		RefreshToken:   "refresh-token",
+		ExpiresAt:      1780862369915,
+		Scope:          "openid profile email data offline_access",
+		TokenType:      "Bearer",
+		OrganizationID: &organizationID,
 	}
 
 	err := svc.storeOpenCosmosSessionSecret(payload, secretName, namespace)
@@ -165,17 +168,19 @@ func TestStoreOpenCosmosSessionSecret(t *testing.T) {
 	require.Equal(t, payload.AccessToken, string(secret.Data["access_token"]))
 	require.Equal(t, payload.RefreshToken, string(secret.Data["refresh_token"]))
 	require.Equal(t, "1780862369915", string(secret.Data["expires_at"]))
+	require.Equal(t, "0", string(secret.Data["organization_id"]))
 	require.Equal(t, payload.Scope, string(secret.Data["scope"]))
 	require.Equal(t, payload.TokenType, string(secret.Data["token_type"]))
 	_, hasUserSub := secret.Data["user_sub"]
 	require.False(t, hasUserSub)
 
 	replacementPayload := OpenCosmosSessionPayload{
-		AccessToken:  "replacement-access-token",
-		RefreshToken: "replacement-refresh-token",
-		ExpiresAt:    1780869999999,
-		Scope:        "openid offline_access",
-		TokenType:    "Bearer",
+		AccessToken:    "replacement-access-token",
+		RefreshToken:   "replacement-refresh-token",
+		ExpiresAt:      1780869999999,
+		Scope:          "openid offline_access",
+		TokenType:      "Bearer",
+		OrganizationID: &replacementOrganizationID,
 	}
 
 	err = svc.storeOpenCosmosSessionSecret(replacementPayload, secretName, namespace)
@@ -190,6 +195,7 @@ func TestStoreOpenCosmosSessionSecret(t *testing.T) {
 	require.Equal(t, replacementPayload.AccessToken, string(replacedSecret.Data["access_token"]))
 	require.Equal(t, replacementPayload.RefreshToken, string(replacedSecret.Data["refresh_token"]))
 	require.Equal(t, "1780869999999", string(replacedSecret.Data["expires_at"]))
+	require.Equal(t, "166", string(replacedSecret.Data["organization_id"]))
 	require.Equal(t, replacementPayload.Scope, string(replacedSecret.Data["scope"]))
 }
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1528,6 +1528,9 @@ const docTemplate = `{
                 "expiresAt": {
                     "type": "integer"
                 },
+                "organization_id": {
+                    "type": "integer"
+                },
                 "refreshToken": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1520,6 +1520,9 @@
                 "expiresAt": {
                     "type": "integer"
                 },
+                "organization_id": {
+                    "type": "integer"
+                },
                 "refreshToken": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -192,6 +192,8 @@ definitions:
         type: string
       expiresAt:
         type: integer
+      organization_id:
+        type: integer
       refreshToken:
         type: string
       scope:


### PR DESCRIPTION
workspace-services validates that organization_id is present and non-negative, then stores it in the workspace-level oauth-opencosmos Kubernetes Secret alongside the Open Cosmos tokens.

<img width="1512" height="843" alt="image" src="https://github.com/user-attachments/assets/77ea0fe2-9cf1-430c-844f-7c6093ab3773" />
